### PR TITLE
Site redesign

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "stylelint-config-standard"
+}

--- a/docs/CONTENT_INVENTORY.md
+++ b/docs/CONTENT_INVENTORY.md
@@ -1,0 +1,265 @@
+# Contoso Ltd — Site Content Inventory
+> Milestone 1 audit: every data element, section, table, link, and interactive
+> component currently present in docs/index.html + docs/styles.css.
+> This file guides Milestone 2 (full redesign with Tailwind CSS).
+
+---
+
+## 1. Page Identity
+
+| Field | Value |
+|---|---|
+| `<title>` | Contoso Ltd - Project Server 2005 |
+| Stylesheet | `styles.css` (retro 2000s enterprise, Verdana/Tahoma, beige/navy palette) |
+| Fonts in use | Verdana, Tahoma, Arial, "Trebuchet MS", "Courier New" |
+| Body background | `#e8e8d8` (warm grey-beige) |
+
+---
+
+## 2. Top Bar (`<div class="topbar">`)
+
+| Element | Detail |
+|---|---|
+| Logo | `logo.gif` — 24×24, yellow CSS fallback box |
+| Title text | **Contoso Ltd — Project Server** |
+| User info | `Logged in as: CONTOSO\ewiberg` |
+| User links | My Settings · Sign Out |
+| CSS | `background: linear-gradient(#003a7a → #002255)`, gold `#f0c040` border-bottom |
+
+---
+
+## 3. Navigation Bar (`<div class="navbar">`)
+
+Six tab-style nav items (table cells). Active = "Project Center".
+
+| Tab | State |
+|---|---|
+| Project Center | **Active** (highlighted) |
+| Resource Center | Default |
+| Status Reports | Default |
+| Documents | Default |
+| Issues & Risks | Default |
+| Admin | Default |
+
+CSS: blue gradient navbar, active tab gets `#f5f5ec` background.
+
+---
+
+## 4. Toolbar (`<div class="toolbar">`)
+
+Button-style text links (no real actions in this static demo):
+
+- [New Project]
+- [Edit]
+- [Delete]
+- separator `|`
+- [Refresh]
+- [Print View]
+- separator `|`
+- [Export to Excel]
+- [Filter: All Projects ▼]
+
+---
+
+## 5. Sidebar (`<td class="sidebar">` — 180 px wide)
+
+### Header
+- Text: **Quick Launch**
+
+### Section: Views
+- ▶ Summary
+- ▶ Gantt Chart
+- ▶ Resource Usage
+- ▶ Cost Tracking
+
+### Section: My Work
+- ▶ My Tasks
+- ▶ My Timesheets
+- ▶ Status Reports
+
+### Section: Reports
+- ▶ Dashboard
+- ▶ Portfolio Analysis
+- ▶ Resource Availability
+
+### Footer
+- `recycle.gif` icon + Recycle Bin link
+
+---
+
+## 6. Main Content Area
+
+### 6a. Page Title & Breadcrumb
+- Title: **Project Center — All Projects** (with `folder.gif` icon)
+- Breadcrumb: `Home > Project Center > All Projects`
+
+---
+
+### 6b. Summary / KPI Boxes (5 boxes, full-width row)
+
+| Label | Value | Colour |
+|---|---|---|
+| Total Projects | **8** | neutral |
+| On Track | **5** | green (`#228b22`) |
+| At Risk | **2** | amber (`#cc8800`) |
+| Critical | **1** | red (`#cc0000`) |
+| Budget Used | **67%** | neutral |
+
+---
+
+### 6c. Main Project Data Table
+
+**Columns:** ☐ | ● | Project Name ▼ | Owner | Start Date | Finish Date | % Complete | Status | Budget | Gantt
+
+**8 rows of project data:**
+
+| # | Project Name | Owner | Start | Finish | % | Status | Budget | Gantt colour |
+|---|---|---|---|---|---|---|---|---|
+| 1 | Q1 2026 Platform Modernization | E. Wiberg | 01/06/2026 | 03/28/2026 | 72% | On Track (green) | $245,000 | green |
+| 2 | API Gateway Migration | K. Jensen | 01/13/2026 | 02/28/2026 | 100% | Complete (green) | $89,000 | blue |
+| 3 | Customer Portal Redesign | M. Andersen | 01/20/2026 | 03/15/2026 | 45% | At Risk (amber) | $178,000 | amber |
+| 4 | Data Warehouse ETL Pipeline | S. Larsen | 02/03/2026 | 04/10/2026 | 30% | On Track (green) | $156,000 | green |
+| 5 | Legacy CRM Data Migration | P. Nielsen | 12/01/2025 | 02/14/2026 | 58% | OVERDUE (red, blinking) | $320,000 | red |
+| 6 | CI/CD Pipeline Overhaul | T. Holm | 01/27/2026 | 03/06/2026 | 88% | On Track (green) | $67,000 | green |
+| 7 | Mobile App v3.0 | L. Poulsen | 02/10/2026 | 05/22/2026 | 15% | At Risk (amber) | $410,000 | amber |
+| 8 | Security Audit & Compliance | A. Krogh | 01/06/2026 | 02/21/2026 | 95% | On Track (green) | $52,000 | blue |
+
+**Progress bar colours:**
+- Default (blue gradient) — On Track / Complete
+- Amber gradient — At Risk
+- Red gradient — OVERDUE/Critical
+
+**Gantt bar styles (inline `margin-left` / `width` percentages):**
+| Row | margin-left | width |
+|---|---|---|
+| 1 (green) | 10% | 62% |
+| 2 (blue) | 15% | 35% |
+| 3 (amber) | 20% | 45% |
+| 4 (green) | 30% | 50% |
+| 5 (red) | 0% | 55% |
+| 6 (green) | 22% | 30% |
+| 7 (amber) | 35% | 60% |
+| 8 (blue) | 10% | 35% |
+
+**Table footer text:** `Showing 1 - 8 of 8 projects`  
+**Pagination controls:** [<< First] [< Prev] **1** [Next >] [Last >>] (static, no real pages)
+
+---
+
+### 6d. Resource Allocation Summary Table
+
+Section heading: **Resource Allocation Summary** (with `chart.gif` icon)
+
+**Columns:** Resource | Department | Allocated Hours | Available Hours | Utilization
+
+**6 rows:**
+
+| Resource | Department | Alloc Hrs | Avail Hrs | Util % | Colour class |
+|---|---|---|---|---|---|
+| E. Wiberg | Engineering | 148 | 160 | 93% | `util-high` (amber) |
+| K. Jensen | Engineering | 120 | 160 | 75% | `util-med` (green) |
+| M. Andersen | Design | 155 | 160 | 97% | `util-over` (red) |
+| S. Larsen | Data | 136 | 160 | 85% | `util-high` (amber) |
+| P. Nielsen | Engineering | 160 | 160 | 100% | `util-over` (red) |
+| T. Holm | DevOps | 112 | 160 | 70% | `util-med` (green) |
+
+Utilisation colour thresholds:
+- `util-med` (≤75%) → green `#228b22`
+- `util-high` (76–95%) → amber `#cc8800`
+- `util-over` (>95%) → red `#cc0000`
+
+---
+
+### 6e. Page Footer
+
+- Copyright: `Microsoft Office Project Server 2005 © Microsoft Corporation. All rights reserved.`
+- Links: Privacy Statement · Terms of Use · Contact Admin
+
+---
+
+## 7. CSS Architecture Summary
+
+### Layout approach
+- 100%-width `<table>` for everything (sidebar + content column split)
+- No flexbox or grid in the original
+
+### Key CSS classes (to be replaced by Tailwind equivalents in M2)
+
+| Original class | Purpose | Tailwind M2 equivalent direction |
+|---|---|---|
+| `.topbar` | Top header bar | `bg-slate-900 border-b border-indigo-500` |
+| `.navbar` | Tab navigation | `bg-slate-800` tabs |
+| `.toolbar` | Action button strip | Icon-button row inside header |
+| `.sidebar` | Left nav panel | Fixed `w-64` side panel |
+| `.sidebar-link` | Nav links | Hover highlight links |
+| `.summary-box` | KPI card | Glass-morphism stat card |
+| `.data-table` | Project/resource grid | Styled `<table>` or card list |
+| `.progress-fill` | Progress bar fill | Tailwind `bg-indigo-500` div bar |
+| `.status-on-track` | Green badge | `bg-emerald-900/50 text-emerald-400` |
+| `.status-at-risk` | Amber badge | `bg-amber-900/50 text-amber-400` |
+| `.status-critical` | Red blinking badge | `bg-red-900/50 text-red-400 animate-pulse` |
+| `.gantt-bar` | Mini Gantt bar | Coloured div with rounded corners |
+| `.util-med/high/over` | Utilisation text colour | Tailwind colour utilities |
+| `.indicator` | Status dot | Rounded full div with colour |
+| `.page-footer` | Bottom copyright bar | `border-t border-slate-700` footer |
+
+### Interactive components
+- Checkboxes (one per row + header select-all) — keep functional in M2
+- Sortable column headers (anchor tags, currently static)
+- Filter dropdown (static text, M2 can add a `<select>`)
+- Nav tab highlighting (active state)
+
+---
+
+## 8. Assets Referenced (missing / placeholder)
+
+| File | Used for | M2 plan |
+|---|---|---|
+| `logo.gif` | Company logo in topbar | Replace with inline SVG or emoji icon |
+| `folder.gif` | Page title icon | Replace with SVG icon |
+| `chart.gif` | Section title icon | Replace with SVG icon |
+| `recycle.gif` | Sidebar footer icon | Replace with SVG icon |
+
+All four GIF files are absent from `docs/` — the CSS already uses coloured box fallbacks.
+In M2, inline SVG icons (Heroicons style) will replace all four references entirely.
+
+---
+
+## 9. Data Preservation Checklist for M2
+
+All of the following **must** appear in the redesigned page:
+
+- [x] Page title: "Contoso Ltd — Project Server" (brand)
+- [x] Logged-in user: `CONTOSO\ewiberg`
+- [x] Top-bar user links: My Settings, Sign Out
+- [x] 6 navigation tabs (Project Center active)
+- [x] Toolbar actions: New Project, Edit, Delete, Refresh, Print View, Export to Excel, Filter
+- [x] Sidebar sections: Views (4 links), My Work (3 links), Reports (3 links), Recycle Bin
+- [x] KPI row: 8 total, 5 on-track, 2 at-risk, 1 critical, 67% budget used
+- [x] All 8 project rows with all column data (name, owner, dates, %, status, budget, Gantt)
+- [x] Progress bars with correct percentages and colours
+- [x] Status badges: On Track / At Risk / OVERDUE / Complete
+- [x] Gantt mini-bars with correct relative offsets and widths
+- [x] "Showing 1 - 8 of 8 projects" + pagination controls
+- [x] Resource Allocation table (6 rows, all columns, correct utilisation colours)
+- [x] Page footer: copyright text + 3 footer links
+
+---
+
+## 10. M2 Design Decisions (pre-planned)
+
+- **Framework:** Tailwind CSS v3 via CDN (Play CDN) — no build step
+- **Colour palette:**
+  - Background: `slate-950` / `slate-900`
+  - Cards: `slate-800/50` with `backdrop-blur` (glass-morphism)
+  - Accent: `indigo-500` / `violet-500`
+  - Success: `emerald-400`
+  - Warning: `amber-400`
+  - Danger: `red-400`
+  - Text primary: `slate-100`
+  - Text secondary: `slate-400`
+- **Typography:** Inter (Google Fonts CDN)
+- **Layout:** CSS Grid sidebar + main, Tailwind responsive breakpoints
+- **Mobile:** sidebar collapses to hamburger menu on `md:` breakpoint
+- **Icons:** Inline SVG (no external icon library needed)
+- **No backend changes**, no `node_modules` additions, deploy pipeline untouched

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,14 +30,14 @@
   <!-- ╔══════════════════════════════════════════════════════╗ -->
   <!-- ║  STICKY HEADER                                       ║ -->
   <!-- ╚══════════════════════════════════════════════════════╝ -->
-  <header id="site-header" class="sticky top-0 z-50 bg-slate-900/95 backdrop-blur border-b border-slate-700/30">
-    <div class="flex items-center justify-between px-4 lg:px-8 h-14">
+  <header id="site-header" class="sticky top-0 z-40 bg-slate-900/95 backdrop-blur border-b border-slate-700/30">
+    <div class="flex items-center justify-between px-4 lg:px-8 h-16">
 
       <!-- Logo + Brand -->
       <div class="flex items-center gap-3 min-w-0">
         <!-- Hamburger (mobile) -->
         <button id="sidebar-toggle"
-          class="lg:hidden p-1 rounded-md text-slate-400 hover:text-white hover:bg-slate-800 transition-colors duration-150"
+          class="lg:hidden p-2 rounded-md text-slate-400 hover:text-white hover:bg-slate-800 transition-colors duration-150"
           aria-label="Toggle sidebar">
           <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16"/>
@@ -69,13 +69,13 @@
   <!-- ╔══════════════════════════════════════════════════════╗ -->
   <!-- ║  BODY LAYOUT: sidebar + content                     ║ -->
   <!-- ╚══════════════════════════════════════════════════════╝ -->
-  <div class="flex flex-1 overflow-hidden relative">
+  <div class="flex flex-1 overflow-hidden">
 
     <!-- ── SIDEBAR ───────────────────────────────────────────── -->
     <aside id="sidebar"
       class="sidebar-panel w-48 flex-shrink-0 bg-slate-900/50 border-r border-slate-700/30 flex flex-col overflow-y-auto
-             fixed inset-y-0 top-14 left-0 z-40 transform -translate-x-full transition-transform duration-200 ease-in-out
-             lg:static lg:translate-x-0 lg:top-auto lg:inset-y-auto lg:z-auto lg:transition-none">
+             fixed inset-y-0 left-0 z-30 transform -translate-x-full transition-transform duration-200 ease-in-out
+             lg:relative lg:translate-x-0 lg:z-0 lg:transition-none">
 
       <div class="px-2 pt-6 pb-4 flex flex-col gap-1 flex-1">
 
@@ -103,7 +103,7 @@
 
     <!-- Sidebar overlay (mobile) -->
     <div id="sidebar-overlay"
-      class="fixed inset-0 bg-black/50 z-30 hidden lg:hidden"
+      class="fixed inset-0 bg-black/50 z-20 hidden lg:hidden"
       aria-hidden="true"></div>
 
     <!-- ── MAIN CONTENT ──────────────────────────────────────── -->

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,361 +1,729 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="dark">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Contoso Ltd - Project Server 2005</title>
+  <title>Contoso Ltd — Project Center</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      darkMode: 'class',
+      theme: {
+        extend: {
+          colors: {
+            slate: {
+              850: '#0f1829',
+              950: '#060d1a'
+            }
+          },
+          fontFamily: {
+            sans: ['Inter', 'system-ui', '-apple-system', 'sans-serif']
+          }
+        }
+      }
+    }
+  </script>
   <link rel="stylesheet" href="styles.css">
 </head>
-<body>
-  <!-- Top bar -->
-  <div class="topbar">
-    <table width="100%" cellpadding="0" cellspacing="0">
-      <tr>
-        <td class="topbar-left">
-          <img src="logo.gif" alt="Contoso" class="logo-img">
-          <span class="topbar-title">Contoso Ltd &mdash; Project Server</span>
-        </td>
-        <td class="topbar-right">
-          Logged in as: <b>CONTOSO\ewiberg</b> | <a href="#">My Settings</a> | <a href="#">Sign Out</a>
-        </td>
-      </tr>
-    </table>
-  </div>
+<body class="bg-slate-900 text-slate-100 min-h-screen flex flex-col">
 
-  <!-- Navigation bar -->
-  <div class="navbar">
-    <table cellpadding="0" cellspacing="0">
-      <tr>
-        <td class="nav-item nav-active">Project Center</td>
-        <td class="nav-item">Resource Center</td>
-        <td class="nav-item">Status Reports</td>
-        <td class="nav-item">Documents</td>
-        <td class="nav-item">Issues &amp; Risks</td>
-        <td class="nav-item">Admin</td>
-      </tr>
-    </table>
-  </div>
+  <!-- ╔══════════════════════════════════════════════════════╗ -->
+  <!-- ║  STICKY HEADER                                       ║ -->
+  <!-- ╚══════════════════════════════════════════════════════╝ -->
+  <header id="site-header" class="sticky top-0 z-50 bg-slate-900/95 backdrop-blur border-b border-slate-700/60 shadow-lg shadow-black/30">
+    <div class="flex items-center justify-between px-4 lg:px-6 h-14">
 
-  <!-- Toolbar -->
-  <div class="toolbar">
-    <table cellpadding="0" cellspacing="0">
-      <tr>
-        <td class="toolbar-btn">[<u>N</u>ew Project]</td>
-        <td class="toolbar-btn">[<u>E</u>dit]</td>
-        <td class="toolbar-btn">[<u>D</u>elete]</td>
-        <td class="toolbar-sep">|</td>
-        <td class="toolbar-btn">[<u>R</u>efresh]</td>
-        <td class="toolbar-btn">[<u>P</u>rint View]</td>
-        <td class="toolbar-sep">|</td>
-        <td class="toolbar-btn">[Export to <u>E</u>xcel]</td>
-        <td class="toolbar-btn">[<u>F</u>ilter: All Projects &#9660;]</td>
-      </tr>
-    </table>
-  </div>
+      <!-- Logo + Brand -->
+      <div class="flex items-center gap-3">
+        <!-- Hamburger (mobile) -->
+        <button id="sidebar-toggle"
+          class="lg:hidden p-1.5 rounded-md text-slate-400 hover:text-white hover:bg-slate-700 transition-colors duration-150"
+          aria-label="Toggle sidebar">
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16"/>
+          </svg>
+        </button>
 
-  <!-- Main content area -->
-  <table class="main-layout" cellpadding="0" cellspacing="0">
-    <tr>
-      <!-- Sidebar -->
-      <td class="sidebar">
-        <div class="sidebar-header">Quick Launch</div>
-        <div class="sidebar-section">
-          <div class="sidebar-section-title">Views</div>
-          <a href="#" class="sidebar-link">&#9658; Summary</a>
-          <a href="#" class="sidebar-link">&#9658; Gantt Chart</a>
-          <a href="#" class="sidebar-link">&#9658; Resource Usage</a>
-          <a href="#" class="sidebar-link">&#9658; Cost Tracking</a>
+        <!-- Brand mark -->
+        <div class="flex items-center gap-2.5">
+          <div class="w-7 h-7 rounded-lg bg-indigo-600 flex items-center justify-center flex-shrink-0">
+            <svg class="w-4 h-4 text-white" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M3 7a2 2 0 012-2h3l2 3H3V7zm0 0v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-7L10 4H5a2 2 0 00-2 3z"/>
+            </svg>
+          </div>
+          <span class="font-semibold text-white text-sm tracking-wide">Contoso <span class="text-indigo-400">Projects</span></span>
         </div>
-        <div class="sidebar-section">
-          <div class="sidebar-section-title">My Work</div>
-          <a href="#" class="sidebar-link">&#9658; My Tasks</a>
-          <a href="#" class="sidebar-link">&#9658; My Timesheets</a>
-          <a href="#" class="sidebar-link">&#9658; Status Reports</a>
-        </div>
-        <div class="sidebar-section">
-          <div class="sidebar-section-title">Reports</div>
-          <a href="#" class="sidebar-link">&#9658; Dashboard</a>
-          <a href="#" class="sidebar-link">&#9658; Portfolio Analysis</a>
-          <a href="#" class="sidebar-link">&#9658; Resource Availability</a>
-        </div>
-        <hr class="sidebar-hr">
-        <div class="sidebar-footer">
-          <img src="recycle.gif" alt="" class="icon-tiny"> <a href="#">Recycle Bin</a>
-        </div>
-      </td>
+      </div>
 
-      <!-- Content -->
-      <td class="content">
-        <h2 class="page-title">
-          <img src="folder.gif" alt="" class="icon-small"> Project Center &mdash; All Projects
-        </h2>
-        <p class="breadcrumb">Home &gt; Project Center &gt; All Projects</p>
+      <!-- Top nav tabs (hidden on mobile) -->
+      <nav class="hidden md:flex items-center gap-1" role="navigation" aria-label="Main navigation">
+        <a href="#" class="nav-tab nav-tab-active" data-nav="project-center">Project Center</a>
+        <a href="#" class="nav-tab">Resource Center</a>
+        <a href="#" class="nav-tab">Status Reports</a>
+        <a href="#" class="nav-tab">Documents</a>
+        <a href="#" class="nav-tab">Issues &amp; Risks</a>
+        <a href="#" class="nav-tab">Admin</a>
+      </nav>
 
-        <!-- Summary boxes -->
-        <table class="summary-boxes" cellpadding="4" cellspacing="0">
-          <tr>
-            <td class="summary-box">
-              <div class="summary-label">Total Projects</div>
-              <div class="summary-value">8</div>
-            </td>
-            <td class="summary-box">
-              <div class="summary-label">On Track</div>
-              <div class="summary-value summary-green">5</div>
-            </td>
-            <td class="summary-box">
-              <div class="summary-label">At Risk</div>
-              <div class="summary-value summary-amber">2</div>
-            </td>
-            <td class="summary-box">
-              <div class="summary-label">Critical</div>
-              <div class="summary-value summary-red">1</div>
-            </td>
-            <td class="summary-box">
-              <div class="summary-label">Budget Used</div>
-              <div class="summary-value">67%</div>
-            </td>
-          </tr>
-        </table>
+      <!-- User area -->
+      <div class="flex items-center gap-3">
+        <!-- Notification bell -->
+        <button class="relative p-1.5 rounded-md text-slate-400 hover:text-white hover:bg-slate-700 transition-colors duration-150" aria-label="Notifications">
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6 6 0 10-12 0v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"/>
+          </svg>
+          <span class="absolute top-1 right-1 w-2 h-2 bg-indigo-500 rounded-full"></span>
+        </button>
 
-        <!-- Main project table -->
-        <table class="data-table" cellpadding="2" cellspacing="0">
-          <thead>
-            <tr>
-              <th class="col-check"><input type="checkbox"></th>
-              <th class="col-indicator">&nbsp;</th>
-              <th><a href="#">Project Name &#9660;</a></th>
-              <th><a href="#">Owner</a></th>
-              <th><a href="#">Start Date</a></th>
-              <th><a href="#">Finish Date</a></th>
-              <th><a href="#">% Complete</a></th>
-              <th><a href="#">Status</a></th>
-              <th><a href="#">Budget</a></th>
-              <th>Gantt</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr class="row-even">
-              <td class="col-check"><input type="checkbox"></td>
-              <td class="col-indicator"><span class="indicator green"></span></td>
-              <td><a href="#" class="project-link">Q1 2026 Platform Modernization</a></td>
-              <td>E. Wiberg</td>
-              <td>01/06/2026</td>
-              <td>03/28/2026</td>
-              <td>
-                <table class="progress-bar" cellpadding="0" cellspacing="0"><tr>
-                  <td class="progress-fill" style="width:72%"></td>
-                  <td class="progress-empty"></td>
-                </tr></table>
-                <span class="progress-text">72%</span>
-              </td>
-              <td><span class="status-on-track">On Track</span></td>
-              <td class="col-budget">$245,000</td>
-              <td class="col-gantt"><div class="gantt-bar gantt-green" style="margin-left:10%;width:62%"></div></td>
-            </tr>
-            <tr class="row-odd">
-              <td class="col-check"><input type="checkbox"></td>
-              <td class="col-indicator"><span class="indicator green"></span></td>
-              <td><a href="#" class="project-link">API Gateway Migration</a></td>
-              <td>K. Jensen</td>
-              <td>01/13/2026</td>
-              <td>02/28/2026</td>
-              <td>
-                <table class="progress-bar" cellpadding="0" cellspacing="0"><tr>
-                  <td class="progress-fill" style="width:100%"></td>
-                  <td class="progress-empty"></td>
-                </tr></table>
-                <span class="progress-text">100%</span>
-              </td>
-              <td><span class="status-on-track">Complete</span></td>
-              <td class="col-budget">$89,000</td>
-              <td class="col-gantt"><div class="gantt-bar gantt-blue" style="margin-left:15%;width:35%"></div></td>
-            </tr>
-            <tr class="row-even">
-              <td class="col-check"><input type="checkbox"></td>
-              <td class="col-indicator"><span class="indicator amber"></span></td>
-              <td><a href="#" class="project-link">Customer Portal Redesign</a></td>
-              <td>M. Andersen</td>
-              <td>01/20/2026</td>
-              <td>03/15/2026</td>
-              <td>
-                <table class="progress-bar" cellpadding="0" cellspacing="0"><tr>
-                  <td class="progress-fill progress-amber" style="width:45%"></td>
-                  <td class="progress-empty"></td>
-                </tr></table>
-                <span class="progress-text">45%</span>
-              </td>
-              <td><span class="status-at-risk">At Risk</span></td>
-              <td class="col-budget">$178,000</td>
-              <td class="col-gantt"><div class="gantt-bar gantt-amber" style="margin-left:20%;width:45%"></div></td>
-            </tr>
-            <tr class="row-odd">
-              <td class="col-check"><input type="checkbox"></td>
-              <td class="col-indicator"><span class="indicator green"></span></td>
-              <td><a href="#" class="project-link">Data Warehouse ETL Pipeline</a></td>
-              <td>S. Larsen</td>
-              <td>02/03/2026</td>
-              <td>04/10/2026</td>
-              <td>
-                <table class="progress-bar" cellpadding="0" cellspacing="0"><tr>
-                  <td class="progress-fill" style="width:30%"></td>
-                  <td class="progress-empty"></td>
-                </tr></table>
-                <span class="progress-text">30%</span>
-              </td>
-              <td><span class="status-on-track">On Track</span></td>
-              <td class="col-budget">$156,000</td>
-              <td class="col-gantt"><div class="gantt-bar gantt-green" style="margin-left:30%;width:50%"></div></td>
-            </tr>
-            <tr class="row-even">
-              <td class="col-check"><input type="checkbox"></td>
-              <td class="col-indicator"><span class="indicator red"></span></td>
-              <td><a href="#" class="project-link">Legacy CRM Data Migration</a></td>
-              <td>P. Nielsen</td>
-              <td>12/01/2025</td>
-              <td>02/14/2026</td>
-              <td>
-                <table class="progress-bar" cellpadding="0" cellspacing="0"><tr>
-                  <td class="progress-fill progress-red" style="width:58%"></td>
-                  <td class="progress-empty"></td>
-                </tr></table>
-                <span class="progress-text">58%</span>
-              </td>
-              <td><span class="status-critical">OVERDUE</span></td>
-              <td class="col-budget">$320,000</td>
-              <td class="col-gantt"><div class="gantt-bar gantt-red" style="margin-left:0%;width:55%"></div></td>
-            </tr>
-            <tr class="row-odd">
-              <td class="col-check"><input type="checkbox"></td>
-              <td class="col-indicator"><span class="indicator green"></span></td>
-              <td><a href="#" class="project-link">CI/CD Pipeline Overhaul</a></td>
-              <td>T. Holm</td>
-              <td>01/27/2026</td>
-              <td>03/06/2026</td>
-              <td>
-                <table class="progress-bar" cellpadding="0" cellspacing="0"><tr>
-                  <td class="progress-fill" style="width:88%"></td>
-                  <td class="progress-empty"></td>
-                </tr></table>
-                <span class="progress-text">88%</span>
-              </td>
-              <td><span class="status-on-track">On Track</span></td>
-              <td class="col-budget">$67,000</td>
-              <td class="col-gantt"><div class="gantt-bar gantt-green" style="margin-left:22%;width:30%"></div></td>
-            </tr>
-            <tr class="row-even">
-              <td class="col-check"><input type="checkbox"></td>
-              <td class="col-indicator"><span class="indicator amber"></span></td>
-              <td><a href="#" class="project-link">Mobile App v3.0</a></td>
-              <td>L. Poulsen</td>
-              <td>02/10/2026</td>
-              <td>05/22/2026</td>
-              <td>
-                <table class="progress-bar" cellpadding="0" cellspacing="0"><tr>
-                  <td class="progress-fill progress-amber" style="width:15%"></td>
-                  <td class="progress-empty"></td>
-                </tr></table>
-                <span class="progress-text">15%</span>
-              </td>
-              <td><span class="status-at-risk">At Risk</span></td>
-              <td class="col-budget">$410,000</td>
-              <td class="col-gantt"><div class="gantt-bar gantt-amber" style="margin-left:35%;width:60%"></div></td>
-            </tr>
-            <tr class="row-odd">
-              <td class="col-check"><input type="checkbox"></td>
-              <td class="col-indicator"><span class="indicator green"></span></td>
-              <td><a href="#" class="project-link">Security Audit &amp; Compliance</a></td>
-              <td>A. Krogh</td>
-              <td>01/06/2026</td>
-              <td>02/21/2026</td>
-              <td>
-                <table class="progress-bar" cellpadding="0" cellspacing="0"><tr>
-                  <td class="progress-fill" style="width:95%"></td>
-                  <td class="progress-empty"></td>
-                </tr></table>
-                <span class="progress-text">95%</span>
-              </td>
-              <td><span class="status-on-track">On Track</span></td>
-              <td class="col-budget">$52,000</td>
-              <td class="col-gantt"><div class="gantt-bar gantt-blue" style="margin-left:10%;width:35%"></div></td>
-            </tr>
-          </tbody>
-        </table>
-
-        <div class="table-footer">
-          <span>Showing 1 - 8 of 8 projects</span>
-          <span class="paging">[&lt;&lt; First] [&lt; Prev] <b>1</b> [Next &gt;] [Last &gt;&gt;]</span>
+        <!-- User avatar -->
+        <div class="flex items-center gap-2 cursor-pointer group">
+          <div class="w-7 h-7 rounded-full bg-gradient-to-br from-indigo-500 to-violet-600 flex items-center justify-center text-xs font-bold text-white select-none">EW</div>
+          <div class="hidden sm:block">
+            <p class="text-xs font-medium text-white leading-none">E. Wiberg</p>
+            <p class="text-xs text-slate-400 leading-none mt-0.5">CONTOSO\ewiberg</p>
+          </div>
+          <svg class="hidden sm:block w-3.5 h-3.5 text-slate-400 group-hover:text-white transition-colors duration-150" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/>
+          </svg>
         </div>
 
-        <!-- Resource allocation section -->
-        <h3 class="section-title">
-          <img src="chart.gif" alt="" class="icon-small"> Resource Allocation Summary
-        </h3>
-        <table class="data-table resource-table" cellpadding="2" cellspacing="0">
-          <thead>
-            <tr>
-              <th>Resource</th>
-              <th>Department</th>
-              <th>Allocated Hours</th>
-              <th>Available Hours</th>
-              <th>Utilization</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr class="row-even">
-              <td>E. Wiberg</td>
-              <td>Engineering</td>
-              <td>148</td>
-              <td>160</td>
-              <td><span class="util-high">93%</span></td>
-            </tr>
-            <tr class="row-odd">
-              <td>K. Jensen</td>
-              <td>Engineering</td>
-              <td>120</td>
-              <td>160</td>
-              <td><span class="util-med">75%</span></td>
-            </tr>
-            <tr class="row-even">
-              <td>M. Andersen</td>
-              <td>Design</td>
-              <td>155</td>
-              <td>160</td>
-              <td><span class="util-over">97%</span></td>
-            </tr>
-            <tr class="row-odd">
-              <td>S. Larsen</td>
-              <td>Data</td>
-              <td>136</td>
-              <td>160</td>
-              <td><span class="util-high">85%</span></td>
-            </tr>
-            <tr class="row-even">
-              <td>P. Nielsen</td>
-              <td>Engineering</td>
-              <td>160</td>
-              <td>160</td>
-              <td><span class="util-over">100%</span></td>
-            </tr>
-            <tr class="row-odd">
-              <td>T. Holm</td>
-              <td>DevOps</td>
-              <td>112</td>
-              <td>160</td>
-              <td><span class="util-med">70%</span></td>
-            </tr>
-          </tbody>
-        </table>
+        <!-- Sign out link -->
+        <a href="#" class="hidden sm:inline-flex items-center gap-1.5 text-xs text-slate-400 hover:text-white transition-colors duration-150 px-2 py-1 rounded hover:bg-slate-700">
+          <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"/>
+          </svg>
+          Sign Out
+        </a>
+      </div>
+    </div>
+  </header>
 
-        <!-- Footer -->
-        <div class="page-footer">
-          <hr>
-          <table width="100%"><tr>
-            <td>Microsoft Office Project Server 2005 &copy; Microsoft Corporation. All rights reserved.</td>
-            <td align="right"><a href="#">Privacy Statement</a> | <a href="#">Terms of Use</a> | <a href="#">Contact Admin</a></td>
-          </tr></table>
+  <!-- ╔══════════════════════════════════════════════════════╗ -->
+  <!-- ║  BODY LAYOUT: sidebar + content                     ║ -->
+  <!-- ╚══════════════════════════════════════════════════════╝ -->
+  <div class="flex flex-1 overflow-hidden relative">
+
+    <!-- ── SIDEBAR ───────────────────────────────────────────── -->
+    <aside id="sidebar"
+      class="sidebar-panel w-56 flex-shrink-0 bg-slate-900 border-r border-slate-700/60 flex flex-col overflow-y-auto
+             fixed inset-y-0 top-14 left-0 z-40 transform -translate-x-full transition-transform duration-200 ease-in-out
+             lg:static lg:translate-x-0 lg:top-auto lg:inset-y-auto lg:z-auto lg:transition-none">
+
+      <div class="px-3 pt-4 pb-6 flex flex-col gap-6 flex-1">
+
+        <!-- Views section -->
+        <div>
+          <p class="sidebar-section-label">Views</p>
+          <nav class="flex flex-col gap-0.5">
+            <a href="#" class="sidebar-link sidebar-link-active" data-sidebar="summary">
+              <svg class="sidebar-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 10h16M4 14h8M4 18h8"/></svg>
+              Summary
+            </a>
+            <a href="#" class="sidebar-link" data-sidebar="gantt">
+              <svg class="sidebar-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/></svg>
+              Gantt Chart
+            </a>
+            <a href="#" class="sidebar-link" data-sidebar="resource-usage">
+              <svg class="sidebar-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0"/></svg>
+              Resource Usage
+            </a>
+            <a href="#" class="sidebar-link" data-sidebar="cost">
+              <svg class="sidebar-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+              Cost Tracking
+            </a>
+          </nav>
         </div>
-      </td>
-    </tr>
-  </table>
+
+        <!-- My Work section -->
+        <div>
+          <p class="sidebar-section-label">My Work</p>
+          <nav class="flex flex-col gap-0.5">
+            <a href="#" class="sidebar-link" data-sidebar="my-tasks">
+              <svg class="sidebar-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"/></svg>
+              My Tasks
+            </a>
+            <a href="#" class="sidebar-link" data-sidebar="timesheets">
+              <svg class="sidebar-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+              My Timesheets
+            </a>
+            <a href="#" class="sidebar-link" data-sidebar="status-reports">
+              <svg class="sidebar-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
+              Status Reports
+            </a>
+          </nav>
+        </div>
+
+        <!-- Reports section -->
+        <div>
+          <p class="sidebar-section-label">Reports</p>
+          <nav class="flex flex-col gap-0.5">
+            <a href="#" class="sidebar-link" data-sidebar="dashboard">
+              <svg class="sidebar-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+              Dashboard
+            </a>
+            <a href="#" class="sidebar-link" data-sidebar="portfolio">
+              <svg class="sidebar-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M7 12l3-3 3 3 4-4M8 21l4-4 4 4M3 4h18M4 4h16v12a1 1 0 01-1 1H5a1 1 0 01-1-1V4z"/></svg>
+              Portfolio Analysis
+            </a>
+            <a href="#" class="sidebar-link" data-sidebar="resources">
+              <svg class="sidebar-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/></svg>
+              Resource Availability
+            </a>
+          </nav>
+        </div>
+      </div>
+
+      <!-- Sidebar footer -->
+      <div class="px-3 py-3 border-t border-slate-700/60">
+        <a href="#" class="sidebar-link text-slate-500 hover:text-slate-300">
+          <svg class="sidebar-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/></svg>
+          Recycle Bin
+        </a>
+      </div>
+    </aside>
+
+    <!-- Sidebar overlay (mobile) -->
+    <div id="sidebar-overlay"
+      class="fixed inset-0 bg-black/50 z-30 hidden lg:hidden"
+      aria-hidden="true"></div>
+
+    <!-- ── MAIN CONTENT ──────────────────────────────────────── -->
+    <main class="flex-1 overflow-y-auto p-4 lg:p-6 min-w-0">
+
+      <!-- Page heading + breadcrumb -->
+      <div class="mb-6 animate-fade-in">
+        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+          <div>
+            <nav class="flex items-center gap-1.5 text-xs text-slate-500 mb-1.5" aria-label="Breadcrumb">
+              <a href="#" class="hover:text-slate-300 transition-colors duration-150">Home</a>
+              <svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/></svg>
+              <a href="#" class="hover:text-slate-300 transition-colors duration-150">Project Center</a>
+              <svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/></svg>
+              <span class="text-slate-300">All Projects</span>
+            </nav>
+            <h1 class="text-xl font-semibold text-white tracking-tight">Project Center <span class="text-slate-400 font-normal text-base">— All Projects</span></h1>
+          </div>
+
+          <!-- Action toolbar -->
+          <div class="flex items-center flex-wrap gap-2">
+            <button class="toolbar-btn toolbar-btn-primary">
+              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/></svg>
+              New Project
+            </button>
+            <button class="toolbar-btn">
+              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/></svg>
+              Edit
+            </button>
+            <button class="toolbar-btn toolbar-btn-danger">
+              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/></svg>
+              Delete
+            </button>
+            <div class="h-4 w-px bg-slate-700 mx-0.5 hidden sm:block"></div>
+            <button class="toolbar-btn">
+              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/></svg>
+              Refresh
+            </button>
+            <button class="toolbar-btn">
+              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z"/></svg>
+              Print View
+            </button>
+            <button class="toolbar-btn">
+              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/></svg>
+              Export to Excel
+            </button>
+            <button class="toolbar-btn flex items-center gap-1.5">
+              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z"/></svg>
+              Filter: All Projects
+              <svg class="w-3 h-3 text-slate-400" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/></svg>
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- ══════════════════════════════════════════════════════ -->
+      <!-- KPI SUMMARY CARDS                                    -->
+      <!-- ══════════════════════════════════════════════════════ -->
+      <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3 mb-6 animate-fade-in" style="animation-delay:0.05s">
+
+        <!-- Total Projects -->
+        <div class="kpi-card group">
+          <div class="flex items-start justify-between mb-3">
+            <p class="text-xs font-medium text-slate-400 uppercase tracking-wider">Total Projects</p>
+            <div class="kpi-icon bg-indigo-500/20 text-indigo-400">
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M3 7a2 2 0 012-2h3l2 3H3V7zm0 0v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-7L10 4H5a2 2 0 00-2 3z"/></svg>
+            </div>
+          </div>
+          <p class="text-3xl font-bold text-white tracking-tight">8</p>
+          <p class="text-xs text-slate-500 mt-1">Active portfolio</p>
+        </div>
+
+        <!-- On Track -->
+        <div class="kpi-card group">
+          <div class="flex items-start justify-between mb-3">
+            <p class="text-xs font-medium text-slate-400 uppercase tracking-wider">On Track</p>
+            <div class="kpi-icon bg-emerald-500/20 text-emerald-400">
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+            </div>
+          </div>
+          <p class="text-3xl font-bold text-emerald-400 tracking-tight">5</p>
+          <p class="text-xs text-slate-500 mt-1">62.5% of portfolio</p>
+        </div>
+
+        <!-- At Risk -->
+        <div class="kpi-card group">
+          <div class="flex items-start justify-between mb-3">
+            <p class="text-xs font-medium text-slate-400 uppercase tracking-wider">At Risk</p>
+            <div class="kpi-icon bg-amber-500/20 text-amber-400">
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/></svg>
+            </div>
+          </div>
+          <p class="text-3xl font-bold text-amber-400 tracking-tight">2</p>
+          <p class="text-xs text-slate-500 mt-1">Needs attention</p>
+        </div>
+
+        <!-- Critical / Overdue -->
+        <div class="kpi-card group">
+          <div class="flex items-start justify-between mb-3">
+            <p class="text-xs font-medium text-slate-400 uppercase tracking-wider">Critical</p>
+            <div class="kpi-icon bg-red-500/20 text-red-400">
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+            </div>
+          </div>
+          <p class="text-3xl font-bold text-red-400 tracking-tight">1</p>
+          <p class="text-xs text-slate-500 mt-1">Overdue — action needed</p>
+        </div>
+
+        <!-- Budget Used -->
+        <div class="kpi-card group col-span-2 sm:col-span-1">
+          <div class="flex items-start justify-between mb-3">
+            <p class="text-xs font-medium text-slate-400 uppercase tracking-wider">Budget Used</p>
+            <div class="kpi-icon bg-violet-500/20 text-violet-400">
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+            </div>
+          </div>
+          <p class="text-3xl font-bold text-violet-400 tracking-tight">67%</p>
+          <div class="mt-2 h-1.5 bg-slate-700 rounded-full overflow-hidden">
+            <div class="h-full bg-gradient-to-r from-violet-500 to-violet-400 rounded-full" style="width: 67%"></div>
+          </div>
+          <p class="text-xs text-slate-500 mt-1">of total allocation</p>
+        </div>
+      </div>
+
+      <!-- ══════════════════════════════════════════════════════ -->
+      <!-- PROJECTS TABLE CARD                                  -->
+      <!-- ══════════════════════════════════════════════════════ -->
+      <div class="data-card mb-6 animate-fade-in" style="animation-delay:0.10s">
+        <div class="px-5 py-4 border-b border-slate-700/60 flex items-center justify-between">
+          <h2 class="text-sm font-semibold text-white">All Projects</h2>
+          <span class="text-xs text-slate-500">Showing 1–8 of 8</span>
+        </div>
+
+        <!-- Scrollable table wrapper -->
+        <div class="overflow-x-auto">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="border-b border-slate-700/60">
+                <th class="table-th w-8 text-center">
+                  <input type="checkbox" class="rounded border-slate-600 bg-slate-700 text-indigo-500 focus:ring-indigo-500 focus:ring-offset-slate-900 cursor-pointer">
+                </th>
+                <th class="table-th w-6"></th>
+                <th class="table-th text-left">
+                  <button class="flex items-center gap-1 hover:text-white transition-colors duration-150">
+                    Project Name
+                    <svg class="w-3 h-3 text-indigo-400" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/></svg>
+                  </button>
+                </th>
+                <th class="table-th text-left hidden sm:table-cell">Owner</th>
+                <th class="table-th text-left hidden md:table-cell">Start</th>
+                <th class="table-th text-left hidden md:table-cell">Finish</th>
+                <th class="table-th text-left hidden lg:table-cell">Progress</th>
+                <th class="table-th text-left">Status</th>
+                <th class="table-th text-right hidden sm:table-cell">Budget</th>
+                <th class="table-th text-left hidden xl:table-cell">Gantt</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-slate-700/40">
+
+              <!-- Row 1: Q1 2026 Platform Modernization -->
+              <tr class="table-row">
+                <td class="table-td text-center"><input type="checkbox" class="rounded border-slate-600 bg-slate-700 text-indigo-500 focus:ring-indigo-500 focus:ring-offset-slate-900 cursor-pointer"></td>
+                <td class="table-td"><span class="status-dot status-dot-green"></span></td>
+                <td class="table-td font-medium"><a href="#" class="project-link">Q1 2026 Platform Modernization</a></td>
+                <td class="table-td text-slate-400 hidden sm:table-cell">E. Wiberg</td>
+                <td class="table-td text-slate-400 hidden md:table-cell">01/06/2026</td>
+                <td class="table-td text-slate-400 hidden md:table-cell">03/28/2026</td>
+                <td class="table-td hidden lg:table-cell">
+                  <div class="flex items-center gap-2">
+                    <div class="flex-1 h-1.5 bg-slate-700 rounded-full overflow-hidden min-w-16">
+                      <div class="h-full bg-emerald-500 rounded-full" style="width:72%"></div>
+                    </div>
+                    <span class="text-xs text-slate-400 w-8 text-right">72%</span>
+                  </div>
+                </td>
+                <td class="table-td"><span class="status-badge status-badge-green">On Track</span></td>
+                <td class="table-td text-right text-slate-300 hidden sm:table-cell">$245,000</td>
+                <td class="table-td hidden xl:table-cell">
+                  <div class="gantt-track"><div class="gantt-fill bg-emerald-500/70" style="margin-left:10%;width:62%"></div></div>
+                </td>
+              </tr>
+
+              <!-- Row 2: API Gateway Migration -->
+              <tr class="table-row">
+                <td class="table-td text-center"><input type="checkbox" class="rounded border-slate-600 bg-slate-700 text-indigo-500 focus:ring-indigo-500 focus:ring-offset-slate-900 cursor-pointer"></td>
+                <td class="table-td"><span class="status-dot status-dot-indigo"></span></td>
+                <td class="table-td font-medium"><a href="#" class="project-link">API Gateway Migration</a></td>
+                <td class="table-td text-slate-400 hidden sm:table-cell">K. Jensen</td>
+                <td class="table-td text-slate-400 hidden md:table-cell">01/13/2026</td>
+                <td class="table-td text-slate-400 hidden md:table-cell">02/28/2026</td>
+                <td class="table-td hidden lg:table-cell">
+                  <div class="flex items-center gap-2">
+                    <div class="flex-1 h-1.5 bg-slate-700 rounded-full overflow-hidden min-w-16">
+                      <div class="h-full bg-indigo-500 rounded-full" style="width:100%"></div>
+                    </div>
+                    <span class="text-xs text-slate-400 w-8 text-right">100%</span>
+                  </div>
+                </td>
+                <td class="table-td"><span class="status-badge status-badge-indigo">Complete</span></td>
+                <td class="table-td text-right text-slate-300 hidden sm:table-cell">$89,000</td>
+                <td class="table-td hidden xl:table-cell">
+                  <div class="gantt-track"><div class="gantt-fill bg-indigo-500/70" style="margin-left:15%;width:35%"></div></div>
+                </td>
+              </tr>
+
+              <!-- Row 3: Customer Portal Redesign -->
+              <tr class="table-row">
+                <td class="table-td text-center"><input type="checkbox" class="rounded border-slate-600 bg-slate-700 text-indigo-500 focus:ring-indigo-500 focus:ring-offset-slate-900 cursor-pointer"></td>
+                <td class="table-td"><span class="status-dot status-dot-amber"></span></td>
+                <td class="table-td font-medium"><a href="#" class="project-link">Customer Portal Redesign</a></td>
+                <td class="table-td text-slate-400 hidden sm:table-cell">M. Andersen</td>
+                <td class="table-td text-slate-400 hidden md:table-cell">01/20/2026</td>
+                <td class="table-td text-slate-400 hidden md:table-cell">03/15/2026</td>
+                <td class="table-td hidden lg:table-cell">
+                  <div class="flex items-center gap-2">
+                    <div class="flex-1 h-1.5 bg-slate-700 rounded-full overflow-hidden min-w-16">
+                      <div class="h-full bg-amber-500 rounded-full" style="width:45%"></div>
+                    </div>
+                    <span class="text-xs text-slate-400 w-8 text-right">45%</span>
+                  </div>
+                </td>
+                <td class="table-td"><span class="status-badge status-badge-amber">At Risk</span></td>
+                <td class="table-td text-right text-slate-300 hidden sm:table-cell">$178,000</td>
+                <td class="table-td hidden xl:table-cell">
+                  <div class="gantt-track"><div class="gantt-fill bg-amber-500/70" style="margin-left:20%;width:45%"></div></div>
+                </td>
+              </tr>
+
+              <!-- Row 4: Data Warehouse ETL Pipeline -->
+              <tr class="table-row">
+                <td class="table-td text-center"><input type="checkbox" class="rounded border-slate-600 bg-slate-700 text-indigo-500 focus:ring-indigo-500 focus:ring-offset-slate-900 cursor-pointer"></td>
+                <td class="table-td"><span class="status-dot status-dot-green"></span></td>
+                <td class="table-td font-medium"><a href="#" class="project-link">Data Warehouse ETL Pipeline</a></td>
+                <td class="table-td text-slate-400 hidden sm:table-cell">S. Larsen</td>
+                <td class="table-td text-slate-400 hidden md:table-cell">02/03/2026</td>
+                <td class="table-td text-slate-400 hidden md:table-cell">04/10/2026</td>
+                <td class="table-td hidden lg:table-cell">
+                  <div class="flex items-center gap-2">
+                    <div class="flex-1 h-1.5 bg-slate-700 rounded-full overflow-hidden min-w-16">
+                      <div class="h-full bg-emerald-500 rounded-full" style="width:30%"></div>
+                    </div>
+                    <span class="text-xs text-slate-400 w-8 text-right">30%</span>
+                  </div>
+                </td>
+                <td class="table-td"><span class="status-badge status-badge-green">On Track</span></td>
+                <td class="table-td text-right text-slate-300 hidden sm:table-cell">$156,000</td>
+                <td class="table-td hidden xl:table-cell">
+                  <div class="gantt-track"><div class="gantt-fill bg-emerald-500/70" style="margin-left:30%;width:50%"></div></div>
+                </td>
+              </tr>
+
+              <!-- Row 5: Legacy CRM Data Migration (OVERDUE) -->
+              <tr class="table-row">
+                <td class="table-td text-center"><input type="checkbox" class="rounded border-slate-600 bg-slate-700 text-indigo-500 focus:ring-indigo-500 focus:ring-offset-slate-900 cursor-pointer"></td>
+                <td class="table-td"><span class="status-dot status-dot-red status-pulse"></span></td>
+                <td class="table-td font-medium"><a href="#" class="project-link">Legacy CRM Data Migration</a></td>
+                <td class="table-td text-slate-400 hidden sm:table-cell">P. Nielsen</td>
+                <td class="table-td text-slate-400 hidden md:table-cell">12/01/2025</td>
+                <td class="table-td text-red-400 hidden md:table-cell">02/14/2026</td>
+                <td class="table-td hidden lg:table-cell">
+                  <div class="flex items-center gap-2">
+                    <div class="flex-1 h-1.5 bg-slate-700 rounded-full overflow-hidden min-w-16">
+                      <div class="h-full bg-red-500 rounded-full" style="width:58%"></div>
+                    </div>
+                    <span class="text-xs text-slate-400 w-8 text-right">58%</span>
+                  </div>
+                </td>
+                <td class="table-td"><span class="status-badge status-badge-red">OVERDUE</span></td>
+                <td class="table-td text-right text-slate-300 hidden sm:table-cell">$320,000</td>
+                <td class="table-td hidden xl:table-cell">
+                  <div class="gantt-track"><div class="gantt-fill bg-red-500/70" style="margin-left:0%;width:55%"></div></div>
+                </td>
+              </tr>
+
+              <!-- Row 6: CI/CD Pipeline Overhaul -->
+              <tr class="table-row">
+                <td class="table-td text-center"><input type="checkbox" class="rounded border-slate-600 bg-slate-700 text-indigo-500 focus:ring-indigo-500 focus:ring-offset-slate-900 cursor-pointer"></td>
+                <td class="table-td"><span class="status-dot status-dot-green"></span></td>
+                <td class="table-td font-medium"><a href="#" class="project-link">CI/CD Pipeline Overhaul</a></td>
+                <td class="table-td text-slate-400 hidden sm:table-cell">T. Holm</td>
+                <td class="table-td text-slate-400 hidden md:table-cell">01/27/2026</td>
+                <td class="table-td text-slate-400 hidden md:table-cell">03/06/2026</td>
+                <td class="table-td hidden lg:table-cell">
+                  <div class="flex items-center gap-2">
+                    <div class="flex-1 h-1.5 bg-slate-700 rounded-full overflow-hidden min-w-16">
+                      <div class="h-full bg-emerald-500 rounded-full" style="width:88%"></div>
+                    </div>
+                    <span class="text-xs text-slate-400 w-8 text-right">88%</span>
+                  </div>
+                </td>
+                <td class="table-td"><span class="status-badge status-badge-green">On Track</span></td>
+                <td class="table-td text-right text-slate-300 hidden sm:table-cell">$67,000</td>
+                <td class="table-td hidden xl:table-cell">
+                  <div class="gantt-track"><div class="gantt-fill bg-emerald-500/70" style="margin-left:22%;width:30%"></div></div>
+                </td>
+              </tr>
+
+              <!-- Row 7: Mobile App v3.0 -->
+              <tr class="table-row">
+                <td class="table-td text-center"><input type="checkbox" class="rounded border-slate-600 bg-slate-700 text-indigo-500 focus:ring-indigo-500 focus:ring-offset-slate-900 cursor-pointer"></td>
+                <td class="table-td"><span class="status-dot status-dot-amber"></span></td>
+                <td class="table-td font-medium"><a href="#" class="project-link">Mobile App v3.0</a></td>
+                <td class="table-td text-slate-400 hidden sm:table-cell">L. Poulsen</td>
+                <td class="table-td text-slate-400 hidden md:table-cell">02/10/2026</td>
+                <td class="table-td text-slate-400 hidden md:table-cell">05/22/2026</td>
+                <td class="table-td hidden lg:table-cell">
+                  <div class="flex items-center gap-2">
+                    <div class="flex-1 h-1.5 bg-slate-700 rounded-full overflow-hidden min-w-16">
+                      <div class="h-full bg-amber-500 rounded-full" style="width:15%"></div>
+                    </div>
+                    <span class="text-xs text-slate-400 w-8 text-right">15%</span>
+                  </div>
+                </td>
+                <td class="table-td"><span class="status-badge status-badge-amber">At Risk</span></td>
+                <td class="table-td text-right text-slate-300 hidden sm:table-cell">$410,000</td>
+                <td class="table-td hidden xl:table-cell">
+                  <div class="gantt-track"><div class="gantt-fill bg-amber-500/70" style="margin-left:35%;width:60%"></div></div>
+                </td>
+              </tr>
+
+              <!-- Row 8: Security Audit & Compliance -->
+              <tr class="table-row">
+                <td class="table-td text-center"><input type="checkbox" class="rounded border-slate-600 bg-slate-700 text-indigo-500 focus:ring-indigo-500 focus:ring-offset-slate-900 cursor-pointer"></td>
+                <td class="table-td"><span class="status-dot status-dot-green"></span></td>
+                <td class="table-td font-medium"><a href="#" class="project-link">Security Audit &amp; Compliance</a></td>
+                <td class="table-td text-slate-400 hidden sm:table-cell">A. Krogh</td>
+                <td class="table-td text-slate-400 hidden md:table-cell">01/06/2026</td>
+                <td class="table-td text-slate-400 hidden md:table-cell">02/21/2026</td>
+                <td class="table-td hidden lg:table-cell">
+                  <div class="flex items-center gap-2">
+                    <div class="flex-1 h-1.5 bg-slate-700 rounded-full overflow-hidden min-w-16">
+                      <div class="h-full bg-emerald-500 rounded-full" style="width:95%"></div>
+                    </div>
+                    <span class="text-xs text-slate-400 w-8 text-right">95%</span>
+                  </div>
+                </td>
+                <td class="table-td"><span class="status-badge status-badge-green">On Track</span></td>
+                <td class="table-td text-right text-slate-300 hidden sm:table-cell">$52,000</td>
+                <td class="table-td hidden xl:table-cell">
+                  <div class="gantt-track"><div class="gantt-fill bg-indigo-500/70" style="margin-left:10%;width:35%"></div></div>
+                </td>
+              </tr>
+
+            </tbody>
+          </table>
+        </div>
+
+        <!-- Table footer / pagination -->
+        <div class="px-5 py-3 border-t border-slate-700/60 flex items-center justify-between text-xs text-slate-500">
+          <span>Showing 1 – 8 of 8 projects</span>
+          <div class="flex items-center gap-1">
+            <button class="px-2 py-1 rounded hover:bg-slate-700 hover:text-white transition-colors duration-150">&laquo; First</button>
+            <button class="px-2 py-1 rounded hover:bg-slate-700 hover:text-white transition-colors duration-150">&lsaquo; Prev</button>
+            <button class="px-2.5 py-1 rounded bg-indigo-600 text-white font-medium">1</button>
+            <button class="px-2 py-1 rounded hover:bg-slate-700 hover:text-white transition-colors duration-150">Next &rsaquo;</button>
+            <button class="px-2 py-1 rounded hover:bg-slate-700 hover:text-white transition-colors duration-150">Last &raquo;</button>
+          </div>
+        </div>
+      </div>
+
+      <!-- ══════════════════════════════════════════════════════ -->
+      <!-- RESOURCE ALLOCATION TABLE                            -->
+      <!-- ══════════════════════════════════════════════════════ -->
+      <div class="data-card mb-6 animate-fade-in" style="animation-delay:0.15s">
+        <div class="px-5 py-4 border-b border-slate-700/60 flex items-center gap-2">
+          <svg class="w-4 h-4 text-indigo-400 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0"/>
+          </svg>
+          <h2 class="text-sm font-semibold text-white">Resource Allocation Summary</h2>
+        </div>
+
+        <div class="overflow-x-auto">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="border-b border-slate-700/60">
+                <th class="table-th text-left">Resource</th>
+                <th class="table-th text-left hidden sm:table-cell">Department</th>
+                <th class="table-th text-right">Allocated Hrs</th>
+                <th class="table-th text-right hidden sm:table-cell">Available Hrs</th>
+                <th class="table-th text-left">Utilization</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-slate-700/40">
+
+              <tr class="table-row">
+                <td class="table-td font-medium text-slate-200">E. Wiberg</td>
+                <td class="table-td text-slate-400 hidden sm:table-cell">Engineering</td>
+                <td class="table-td text-right text-slate-300">148</td>
+                <td class="table-td text-right text-slate-400 hidden sm:table-cell">160</td>
+                <td class="table-td">
+                  <div class="flex items-center gap-2">
+                    <div class="w-20 h-1.5 bg-slate-700 rounded-full overflow-hidden">
+                      <div class="h-full bg-amber-500 rounded-full" style="width:93%"></div>
+                    </div>
+                    <span class="util-badge util-badge-high">93%</span>
+                  </div>
+                </td>
+              </tr>
+
+              <tr class="table-row">
+                <td class="table-td font-medium text-slate-200">K. Jensen</td>
+                <td class="table-td text-slate-400 hidden sm:table-cell">Engineering</td>
+                <td class="table-td text-right text-slate-300">120</td>
+                <td class="table-td text-right text-slate-400 hidden sm:table-cell">160</td>
+                <td class="table-td">
+                  <div class="flex items-center gap-2">
+                    <div class="w-20 h-1.5 bg-slate-700 rounded-full overflow-hidden">
+                      <div class="h-full bg-emerald-500 rounded-full" style="width:75%"></div>
+                    </div>
+                    <span class="util-badge util-badge-med">75%</span>
+                  </div>
+                </td>
+              </tr>
+
+              <tr class="table-row">
+                <td class="table-td font-medium text-slate-200">M. Andersen</td>
+                <td class="table-td text-slate-400 hidden sm:table-cell">Design</td>
+                <td class="table-td text-right text-slate-300">155</td>
+                <td class="table-td text-right text-slate-400 hidden sm:table-cell">160</td>
+                <td class="table-td">
+                  <div class="flex items-center gap-2">
+                    <div class="w-20 h-1.5 bg-slate-700 rounded-full overflow-hidden">
+                      <div class="h-full bg-red-500 rounded-full" style="width:97%"></div>
+                    </div>
+                    <span class="util-badge util-badge-over">97%</span>
+                  </div>
+                </td>
+              </tr>
+
+              <tr class="table-row">
+                <td class="table-td font-medium text-slate-200">S. Larsen</td>
+                <td class="table-td text-slate-400 hidden sm:table-cell">Data</td>
+                <td class="table-td text-right text-slate-300">136</td>
+                <td class="table-td text-right text-slate-400 hidden sm:table-cell">160</td>
+                <td class="table-td">
+                  <div class="flex items-center gap-2">
+                    <div class="w-20 h-1.5 bg-slate-700 rounded-full overflow-hidden">
+                      <div class="h-full bg-amber-500 rounded-full" style="width:85%"></div>
+                    </div>
+                    <span class="util-badge util-badge-high">85%</span>
+                  </div>
+                </td>
+              </tr>
+
+              <tr class="table-row">
+                <td class="table-td font-medium text-slate-200">P. Nielsen</td>
+                <td class="table-td text-slate-400 hidden sm:table-cell">Engineering</td>
+                <td class="table-td text-right text-slate-300">160</td>
+                <td class="table-td text-right text-slate-400 hidden sm:table-cell">160</td>
+                <td class="table-td">
+                  <div class="flex items-center gap-2">
+                    <div class="w-20 h-1.5 bg-slate-700 rounded-full overflow-hidden">
+                      <div class="h-full bg-red-500 rounded-full" style="width:100%"></div>
+                    </div>
+                    <span class="util-badge util-badge-over">100%</span>
+                  </div>
+                </td>
+              </tr>
+
+              <tr class="table-row">
+                <td class="table-td font-medium text-slate-200">T. Holm</td>
+                <td class="table-td text-slate-400 hidden sm:table-cell">DevOps</td>
+                <td class="table-td text-right text-slate-300">112</td>
+                <td class="table-td text-right text-slate-400 hidden sm:table-cell">160</td>
+                <td class="table-td">
+                  <div class="flex items-center gap-2">
+                    <div class="w-20 h-1.5 bg-slate-700 rounded-full overflow-hidden">
+                      <div class="h-full bg-emerald-500 rounded-full" style="width:70%"></div>
+                    </div>
+                    <span class="util-badge util-badge-med">70%</span>
+                  </div>
+                </td>
+              </tr>
+
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- ══════════════════════════════════════════════════════ -->
+      <!-- PAGE FOOTER                                          -->
+      <!-- ══════════════════════════════════════════════════════ -->
+      <footer class="border-t border-slate-700/60 pt-4 pb-6 mt-2">
+        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 text-xs text-slate-500">
+          <span>Microsoft Office Project Server 2005 &copy; Microsoft Corporation. All rights reserved.</span>
+          <div class="flex items-center gap-3">
+            <a href="#" class="hover:text-slate-300 transition-colors duration-150">Privacy Statement</a>
+            <span class="text-slate-700">|</span>
+            <a href="#" class="hover:text-slate-300 transition-colors duration-150">Terms of Use</a>
+            <span class="text-slate-700">|</span>
+            <a href="#" class="hover:text-slate-300 transition-colors duration-150">Contact Admin</a>
+          </div>
+        </div>
+      </footer>
+
+    </main>
+  </div><!-- end flex body -->
+
+  <!-- ╔══════════════════════════════════════════════════════╗ -->
+  <!-- ║  MOBILE SIDEBAR TOGGLE SCRIPT                       ║ -->
+  <!-- ╚══════════════════════════════════════════════════════╝ -->
+  <script>
+    (function () {
+      var toggle = document.getElementById('sidebar-toggle');
+      var sidebar = document.getElementById('sidebar');
+      var overlay = document.getElementById('sidebar-overlay');
+
+      function openSidebar() {
+        sidebar.classList.remove('-translate-x-full');
+        overlay.classList.remove('hidden');
+        document.body.style.overflow = 'hidden';
+      }
+
+      function closeSidebar() {
+        sidebar.classList.add('-translate-x-full');
+        overlay.classList.add('hidden');
+        document.body.style.overflow = '';
+      }
+
+      if (toggle) {
+        toggle.addEventListener('click', function () {
+          if (sidebar.classList.contains('-translate-x-full')) {
+            openSidebar();
+          } else {
+            closeSidebar();
+          }
+        });
+      }
+
+      if (overlay) {
+        overlay.addEventListener('click', closeSidebar);
+      }
+
+      // Close sidebar on Escape key
+      document.addEventListener('keydown', function (e) {
+        if (e.key === 'Escape') { closeSidebar(); }
+      });
+    }());
+  </script>
+
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,8 +30,8 @@
   <!-- ╔══════════════════════════════════════════════════════╗ -->
   <!-- ║  STICKY HEADER                                       ║ -->
   <!-- ╚══════════════════════════════════════════════════════╝ -->
-  <header id="site-header" class="sticky top-0 z-50 bg-slate-900/95 backdrop-blur border-b border-slate-700/60 shadow-lg shadow-black/30">
-    <div class="flex items-center justify-between px-4 lg:px-6 h-14">
+  <header id="site-header" class="sticky top-0 z-50 bg-slate-900 border-b border-slate-700/60">
+    <div class="flex items-center justify-between px-4 lg:px-6 h-16">
 
       <!-- Logo + Brand -->
       <div class="flex items-center gap-3">
@@ -109,68 +109,27 @@
              fixed inset-y-0 top-14 left-0 z-40 transform -translate-x-full transition-transform duration-200 ease-in-out
              lg:static lg:translate-x-0 lg:top-auto lg:inset-y-auto lg:z-auto lg:transition-none">
 
-      <div class="px-3 pt-4 pb-6 flex flex-col gap-6 flex-1">
+      <div class="px-3 pt-4 pb-6 flex flex-col gap-4 flex-1">
 
-        <!-- Views section -->
-        <div>
-          <p class="sidebar-section-label">Views</p>
-          <nav class="flex flex-col gap-0.5">
-            <a href="#" class="sidebar-link sidebar-link-active" data-sidebar="summary">
-              <svg class="sidebar-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 10h16M4 14h8M4 18h8"/></svg>
-              Summary
-            </a>
-            <a href="#" class="sidebar-link" data-sidebar="gantt">
-              <svg class="sidebar-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/></svg>
-              Gantt Chart
-            </a>
-            <a href="#" class="sidebar-link" data-sidebar="resource-usage">
-              <svg class="sidebar-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0"/></svg>
-              Resource Usage
-            </a>
-            <a href="#" class="sidebar-link" data-sidebar="cost">
-              <svg class="sidebar-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
-              Cost Tracking
-            </a>
-          </nav>
-        </div>
-
-        <!-- My Work section -->
-        <div>
-          <p class="sidebar-section-label">My Work</p>
-          <nav class="flex flex-col gap-0.5">
-            <a href="#" class="sidebar-link" data-sidebar="my-tasks">
-              <svg class="sidebar-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"/></svg>
-              My Tasks
-            </a>
-            <a href="#" class="sidebar-link" data-sidebar="timesheets">
-              <svg class="sidebar-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
-              My Timesheets
-            </a>
-            <a href="#" class="sidebar-link" data-sidebar="status-reports">
-              <svg class="sidebar-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
-              Status Reports
-            </a>
-          </nav>
-        </div>
-
-        <!-- Reports section -->
-        <div>
-          <p class="sidebar-section-label">Reports</p>
-          <nav class="flex flex-col gap-0.5">
-            <a href="#" class="sidebar-link" data-sidebar="dashboard">
-              <svg class="sidebar-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
-              Dashboard
-            </a>
-            <a href="#" class="sidebar-link" data-sidebar="portfolio">
-              <svg class="sidebar-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M7 12l3-3 3 3 4-4M8 21l4-4 4 4M3 4h18M4 4h16v12a1 1 0 01-1 1H5a1 1 0 01-1-1V4z"/></svg>
-              Portfolio Analysis
-            </a>
-            <a href="#" class="sidebar-link" data-sidebar="resources">
-              <svg class="sidebar-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/></svg>
-              Resource Availability
-            </a>
-          </nav>
-        </div>
+        <!-- Navigation section -->
+        <nav class="flex flex-col gap-0.5">
+          <a href="#" class="sidebar-link sidebar-link-active">
+            <svg class="sidebar-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 10h16M4 14h16M4 18h16"/></svg>
+            Project Center
+          </a>
+          <a href="#" class="sidebar-link">
+            <svg class="sidebar-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/></svg>
+            Reports
+          </a>
+          <a href="#" class="sidebar-link">
+            <svg class="sidebar-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0"/></svg>
+            Resources
+          </a>
+          <a href="#" class="sidebar-link">
+            <svg class="sidebar-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/></svg>
+            My Tasks
+          </a>
+        </nav>
       </div>
 
       <!-- Sidebar footer -->
@@ -190,122 +149,63 @@
     <!-- ── MAIN CONTENT ──────────────────────────────────────── -->
     <main class="flex-1 overflow-y-auto p-4 lg:p-6 min-w-0">
 
-      <!-- Page heading + breadcrumb -->
+      <!-- Page heading -->
       <div class="mb-6 animate-fade-in">
-        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-          <div>
-            <nav class="flex items-center gap-1.5 text-xs text-slate-500 mb-1.5" aria-label="Breadcrumb">
-              <a href="#" class="hover:text-slate-300 transition-colors duration-150">Home</a>
-              <svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/></svg>
-              <a href="#" class="hover:text-slate-300 transition-colors duration-150">Project Center</a>
-              <svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/></svg>
-              <span class="text-slate-300">All Projects</span>
-            </nav>
-            <h1 class="text-xl font-semibold text-white tracking-tight">Project Center <span class="text-slate-400 font-normal text-base">— All Projects</span></h1>
-          </div>
-
-          <!-- Action toolbar -->
-          <div class="flex items-center flex-wrap gap-2">
-            <button class="toolbar-btn toolbar-btn-primary">
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/></svg>
-              New Project
-            </button>
-            <button class="toolbar-btn">
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/></svg>
-              Edit
-            </button>
-            <button class="toolbar-btn toolbar-btn-danger">
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/></svg>
-              Delete
-            </button>
-            <div class="h-4 w-px bg-slate-700 mx-0.5 hidden sm:block"></div>
-            <button class="toolbar-btn">
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/></svg>
-              Refresh
-            </button>
-            <button class="toolbar-btn">
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z"/></svg>
-              Print View
-            </button>
-            <button class="toolbar-btn">
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/></svg>
-              Export to Excel
-            </button>
-            <button class="toolbar-btn flex items-center gap-1.5">
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z"/></svg>
-              Filter: All Projects
-              <svg class="w-3 h-3 text-slate-400" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/></svg>
-            </button>
-          </div>
-        </div>
+        <h1 class="text-2xl font-bold text-white tracking-tight">Project Center</h1>
+        <p class="text-slate-400 text-sm mt-1">All Projects &amp; Portfolio Overview</p>
       </div>
 
       <!-- ══════════════════════════════════════════════════════ -->
       <!-- KPI SUMMARY CARDS                                    -->
       <!-- ══════════════════════════════════════════════════════ -->
-      <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3 mb-6 animate-fade-in" style="animation-delay:0.05s">
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-6 animate-fade-in" style="animation-delay:0.05s">
 
         <!-- Total Projects -->
-        <div class="kpi-card group">
-          <div class="flex items-start justify-between mb-3">
-            <p class="text-xs font-medium text-slate-400 uppercase tracking-wider">Total Projects</p>
+        <div class="kpi-card">
+          <div class="flex items-start justify-between mb-2">
+            <p class="text-xs font-semibold text-slate-400 uppercase tracking-wide">Total Projects</p>
             <div class="kpi-icon bg-indigo-500/20 text-indigo-400">
               <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M3 7a2 2 0 012-2h3l2 3H3V7zm0 0v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-7L10 4H5a2 2 0 00-2 3z"/></svg>
             </div>
           </div>
-          <p class="text-3xl font-bold text-white tracking-tight">8</p>
+          <p class="text-3xl font-bold text-white">8</p>
           <p class="text-xs text-slate-500 mt-1">Active portfolio</p>
         </div>
 
         <!-- On Track -->
-        <div class="kpi-card group">
-          <div class="flex items-start justify-between mb-3">
-            <p class="text-xs font-medium text-slate-400 uppercase tracking-wider">On Track</p>
+        <div class="kpi-card">
+          <div class="flex items-start justify-between mb-2">
+            <p class="text-xs font-semibold text-slate-400 uppercase tracking-wide">On Track</p>
             <div class="kpi-icon bg-emerald-500/20 text-emerald-400">
               <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
             </div>
           </div>
-          <p class="text-3xl font-bold text-emerald-400 tracking-tight">5</p>
+          <p class="text-3xl font-bold text-emerald-400">5</p>
           <p class="text-xs text-slate-500 mt-1">62.5% of portfolio</p>
         </div>
 
         <!-- At Risk -->
-        <div class="kpi-card group">
-          <div class="flex items-start justify-between mb-3">
-            <p class="text-xs font-medium text-slate-400 uppercase tracking-wider">At Risk</p>
+        <div class="kpi-card">
+          <div class="flex items-start justify-between mb-2">
+            <p class="text-xs font-semibold text-slate-400 uppercase tracking-wide">At Risk</p>
             <div class="kpi-icon bg-amber-500/20 text-amber-400">
               <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/></svg>
             </div>
           </div>
-          <p class="text-3xl font-bold text-amber-400 tracking-tight">2</p>
+          <p class="text-3xl font-bold text-amber-400">2</p>
           <p class="text-xs text-slate-500 mt-1">Needs attention</p>
         </div>
 
         <!-- Critical / Overdue -->
-        <div class="kpi-card group">
-          <div class="flex items-start justify-between mb-3">
-            <p class="text-xs font-medium text-slate-400 uppercase tracking-wider">Critical</p>
+        <div class="kpi-card">
+          <div class="flex items-start justify-between mb-2">
+            <p class="text-xs font-semibold text-slate-400 uppercase tracking-wide">Critical</p>
             <div class="kpi-icon bg-red-500/20 text-red-400">
               <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
             </div>
           </div>
-          <p class="text-3xl font-bold text-red-400 tracking-tight">1</p>
-          <p class="text-xs text-slate-500 mt-1">Overdue — action needed</p>
-        </div>
-
-        <!-- Budget Used -->
-        <div class="kpi-card group col-span-2 sm:col-span-1">
-          <div class="flex items-start justify-between mb-3">
-            <p class="text-xs font-medium text-slate-400 uppercase tracking-wider">Budget Used</p>
-            <div class="kpi-icon bg-violet-500/20 text-violet-400">
-              <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
-            </div>
-          </div>
-          <p class="text-3xl font-bold text-violet-400 tracking-tight">67%</p>
-          <div class="mt-2 h-1.5 bg-slate-700 rounded-full overflow-hidden">
-            <div class="h-full bg-gradient-to-r from-violet-500 to-violet-400 rounded-full" style="width: 67%"></div>
-          </div>
-          <p class="text-xs text-slate-500 mt-1">of total allocation</p>
+          <p class="text-3xl font-bold text-red-400">1</p>
+          <p class="text-xs text-slate-500 mt-1">Overdue</p>
         </div>
       </div>
 
@@ -313,9 +213,8 @@
       <!-- PROJECTS TABLE CARD                                  -->
       <!-- ══════════════════════════════════════════════════════ -->
       <div class="data-card mb-6 animate-fade-in" style="animation-delay:0.10s">
-        <div class="px-5 py-4 border-b border-slate-700/60 flex items-center justify-between">
-          <h2 class="text-sm font-semibold text-white">All Projects</h2>
-          <span class="text-xs text-slate-500">Showing 1–8 of 8</span>
+        <div class="px-6 py-4 border-b border-slate-700/60">
+          <h2 class="text-base font-semibold text-white">All Projects (8)</h2>
         </div>
 
         <!-- Scrollable table wrapper -->
@@ -323,225 +222,145 @@
           <table class="w-full text-sm">
             <thead>
               <tr class="border-b border-slate-700/60">
-                <th class="table-th w-8 text-center">
-                  <input type="checkbox" class="rounded border-slate-600 bg-slate-700 text-indigo-500 focus:ring-indigo-500 focus:ring-offset-slate-900 cursor-pointer">
-                </th>
-                <th class="table-th w-6"></th>
-                <th class="table-th text-left">
-                  <button class="flex items-center gap-1 hover:text-white transition-colors duration-150">
-                    Project Name
-                    <svg class="w-3 h-3 text-indigo-400" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/></svg>
-                  </button>
-                </th>
+                <th class="table-th text-left">Project</th>
                 <th class="table-th text-left hidden sm:table-cell">Owner</th>
-                <th class="table-th text-left hidden md:table-cell">Start</th>
-                <th class="table-th text-left hidden md:table-cell">Finish</th>
-                <th class="table-th text-left hidden lg:table-cell">Progress</th>
-                <th class="table-th text-left">Status</th>
-                <th class="table-th text-right hidden sm:table-cell">Budget</th>
-                <th class="table-th text-left hidden xl:table-cell">Gantt</th>
+                <th class="table-th text-center">Progress</th>
+                <th class="table-th text-center">Status</th>
+                <th class="table-th text-right hidden md:table-cell">Budget</th>
               </tr>
             </thead>
             <tbody class="divide-y divide-slate-700/40">
 
-              <!-- Row 1: Q1 2026 Platform Modernization -->
+              <!-- Row 1 -->
               <tr class="table-row">
-                <td class="table-td text-center"><input type="checkbox" class="rounded border-slate-600 bg-slate-700 text-indigo-500 focus:ring-indigo-500 focus:ring-offset-slate-900 cursor-pointer"></td>
-                <td class="table-td"><span class="status-dot status-dot-green"></span></td>
                 <td class="table-td font-medium"><a href="#" class="project-link">Q1 2026 Platform Modernization</a></td>
                 <td class="table-td text-slate-400 hidden sm:table-cell">E. Wiberg</td>
-                <td class="table-td text-slate-400 hidden md:table-cell">01/06/2026</td>
-                <td class="table-td text-slate-400 hidden md:table-cell">03/28/2026</td>
-                <td class="table-td hidden lg:table-cell">
-                  <div class="flex items-center gap-2">
-                    <div class="flex-1 h-1.5 bg-slate-700 rounded-full overflow-hidden min-w-16">
-                      <div class="h-full bg-emerald-500 rounded-full" style="width:72%"></div>
+                <td class="table-td">
+                  <div class="flex items-center justify-center gap-1.5">
+                    <div class="w-16 h-1.5 bg-slate-700 rounded-full overflow-hidden">
+                      <div class="h-full bg-emerald-500" style="width:72%"></div>
                     </div>
                     <span class="text-xs text-slate-400 w-8 text-right">72%</span>
                   </div>
                 </td>
-                <td class="table-td"><span class="status-badge status-badge-green">On Track</span></td>
-                <td class="table-td text-right text-slate-300 hidden sm:table-cell">$245,000</td>
-                <td class="table-td hidden xl:table-cell">
-                  <div class="gantt-track"><div class="gantt-fill bg-emerald-500/70" style="margin-left:10%;width:62%"></div></div>
-                </td>
+                <td class="table-td text-center"><span class="status-badge status-badge-green">On Track</span></td>
+                <td class="table-td text-right text-slate-300 hidden md:table-cell">$245K</td>
               </tr>
 
-              <!-- Row 2: API Gateway Migration -->
+              <!-- Row 2 -->
               <tr class="table-row">
-                <td class="table-td text-center"><input type="checkbox" class="rounded border-slate-600 bg-slate-700 text-indigo-500 focus:ring-indigo-500 focus:ring-offset-slate-900 cursor-pointer"></td>
-                <td class="table-td"><span class="status-dot status-dot-indigo"></span></td>
                 <td class="table-td font-medium"><a href="#" class="project-link">API Gateway Migration</a></td>
                 <td class="table-td text-slate-400 hidden sm:table-cell">K. Jensen</td>
-                <td class="table-td text-slate-400 hidden md:table-cell">01/13/2026</td>
-                <td class="table-td text-slate-400 hidden md:table-cell">02/28/2026</td>
-                <td class="table-td hidden lg:table-cell">
-                  <div class="flex items-center gap-2">
-                    <div class="flex-1 h-1.5 bg-slate-700 rounded-full overflow-hidden min-w-16">
-                      <div class="h-full bg-indigo-500 rounded-full" style="width:100%"></div>
+                <td class="table-td">
+                  <div class="flex items-center justify-center gap-1.5">
+                    <div class="w-16 h-1.5 bg-slate-700 rounded-full overflow-hidden">
+                      <div class="h-full bg-indigo-500" style="width:100%"></div>
                     </div>
                     <span class="text-xs text-slate-400 w-8 text-right">100%</span>
                   </div>
                 </td>
-                <td class="table-td"><span class="status-badge status-badge-indigo">Complete</span></td>
-                <td class="table-td text-right text-slate-300 hidden sm:table-cell">$89,000</td>
-                <td class="table-td hidden xl:table-cell">
-                  <div class="gantt-track"><div class="gantt-fill bg-indigo-500/70" style="margin-left:15%;width:35%"></div></div>
-                </td>
+                <td class="table-td text-center"><span class="status-badge status-badge-indigo">Complete</span></td>
+                <td class="table-td text-right text-slate-300 hidden md:table-cell">$89K</td>
               </tr>
 
-              <!-- Row 3: Customer Portal Redesign -->
+              <!-- Row 3 -->
               <tr class="table-row">
-                <td class="table-td text-center"><input type="checkbox" class="rounded border-slate-600 bg-slate-700 text-indigo-500 focus:ring-indigo-500 focus:ring-offset-slate-900 cursor-pointer"></td>
-                <td class="table-td"><span class="status-dot status-dot-amber"></span></td>
                 <td class="table-td font-medium"><a href="#" class="project-link">Customer Portal Redesign</a></td>
                 <td class="table-td text-slate-400 hidden sm:table-cell">M. Andersen</td>
-                <td class="table-td text-slate-400 hidden md:table-cell">01/20/2026</td>
-                <td class="table-td text-slate-400 hidden md:table-cell">03/15/2026</td>
-                <td class="table-td hidden lg:table-cell">
-                  <div class="flex items-center gap-2">
-                    <div class="flex-1 h-1.5 bg-slate-700 rounded-full overflow-hidden min-w-16">
-                      <div class="h-full bg-amber-500 rounded-full" style="width:45%"></div>
+                <td class="table-td">
+                  <div class="flex items-center justify-center gap-1.5">
+                    <div class="w-16 h-1.5 bg-slate-700 rounded-full overflow-hidden">
+                      <div class="h-full bg-amber-500" style="width:45%"></div>
                     </div>
                     <span class="text-xs text-slate-400 w-8 text-right">45%</span>
                   </div>
                 </td>
-                <td class="table-td"><span class="status-badge status-badge-amber">At Risk</span></td>
-                <td class="table-td text-right text-slate-300 hidden sm:table-cell">$178,000</td>
-                <td class="table-td hidden xl:table-cell">
-                  <div class="gantt-track"><div class="gantt-fill bg-amber-500/70" style="margin-left:20%;width:45%"></div></div>
-                </td>
+                <td class="table-td text-center"><span class="status-badge status-badge-amber">At Risk</span></td>
+                <td class="table-td text-right text-slate-300 hidden md:table-cell">$178K</td>
               </tr>
 
-              <!-- Row 4: Data Warehouse ETL Pipeline -->
+              <!-- Row 4 -->
               <tr class="table-row">
-                <td class="table-td text-center"><input type="checkbox" class="rounded border-slate-600 bg-slate-700 text-indigo-500 focus:ring-indigo-500 focus:ring-offset-slate-900 cursor-pointer"></td>
-                <td class="table-td"><span class="status-dot status-dot-green"></span></td>
                 <td class="table-td font-medium"><a href="#" class="project-link">Data Warehouse ETL Pipeline</a></td>
                 <td class="table-td text-slate-400 hidden sm:table-cell">S. Larsen</td>
-                <td class="table-td text-slate-400 hidden md:table-cell">02/03/2026</td>
-                <td class="table-td text-slate-400 hidden md:table-cell">04/10/2026</td>
-                <td class="table-td hidden lg:table-cell">
-                  <div class="flex items-center gap-2">
-                    <div class="flex-1 h-1.5 bg-slate-700 rounded-full overflow-hidden min-w-16">
-                      <div class="h-full bg-emerald-500 rounded-full" style="width:30%"></div>
+                <td class="table-td">
+                  <div class="flex items-center justify-center gap-1.5">
+                    <div class="w-16 h-1.5 bg-slate-700 rounded-full overflow-hidden">
+                      <div class="h-full bg-emerald-500" style="width:30%"></div>
                     </div>
                     <span class="text-xs text-slate-400 w-8 text-right">30%</span>
                   </div>
                 </td>
-                <td class="table-td"><span class="status-badge status-badge-green">On Track</span></td>
-                <td class="table-td text-right text-slate-300 hidden sm:table-cell">$156,000</td>
-                <td class="table-td hidden xl:table-cell">
-                  <div class="gantt-track"><div class="gantt-fill bg-emerald-500/70" style="margin-left:30%;width:50%"></div></div>
-                </td>
+                <td class="table-td text-center"><span class="status-badge status-badge-green">On Track</span></td>
+                <td class="table-td text-right text-slate-300 hidden md:table-cell">$156K</td>
               </tr>
 
-              <!-- Row 5: Legacy CRM Data Migration (OVERDUE) -->
+              <!-- Row 5 -->
               <tr class="table-row">
-                <td class="table-td text-center"><input type="checkbox" class="rounded border-slate-600 bg-slate-700 text-indigo-500 focus:ring-indigo-500 focus:ring-offset-slate-900 cursor-pointer"></td>
-                <td class="table-td"><span class="status-dot status-dot-red status-pulse"></span></td>
                 <td class="table-td font-medium"><a href="#" class="project-link">Legacy CRM Data Migration</a></td>
                 <td class="table-td text-slate-400 hidden sm:table-cell">P. Nielsen</td>
-                <td class="table-td text-slate-400 hidden md:table-cell">12/01/2025</td>
-                <td class="table-td text-red-400 hidden md:table-cell">02/14/2026</td>
-                <td class="table-td hidden lg:table-cell">
-                  <div class="flex items-center gap-2">
-                    <div class="flex-1 h-1.5 bg-slate-700 rounded-full overflow-hidden min-w-16">
-                      <div class="h-full bg-red-500 rounded-full" style="width:58%"></div>
+                <td class="table-td">
+                  <div class="flex items-center justify-center gap-1.5">
+                    <div class="w-16 h-1.5 bg-slate-700 rounded-full overflow-hidden">
+                      <div class="h-full bg-red-500" style="width:58%"></div>
                     </div>
                     <span class="text-xs text-slate-400 w-8 text-right">58%</span>
                   </div>
                 </td>
-                <td class="table-td"><span class="status-badge status-badge-red">OVERDUE</span></td>
-                <td class="table-td text-right text-slate-300 hidden sm:table-cell">$320,000</td>
-                <td class="table-td hidden xl:table-cell">
-                  <div class="gantt-track"><div class="gantt-fill bg-red-500/70" style="margin-left:0%;width:55%"></div></div>
-                </td>
+                <td class="table-td text-center"><span class="status-badge status-badge-red">OVERDUE</span></td>
+                <td class="table-td text-right text-slate-300 hidden md:table-cell">$320K</td>
               </tr>
 
-              <!-- Row 6: CI/CD Pipeline Overhaul -->
+              <!-- Row 6 -->
               <tr class="table-row">
-                <td class="table-td text-center"><input type="checkbox" class="rounded border-slate-600 bg-slate-700 text-indigo-500 focus:ring-indigo-500 focus:ring-offset-slate-900 cursor-pointer"></td>
-                <td class="table-td"><span class="status-dot status-dot-green"></span></td>
                 <td class="table-td font-medium"><a href="#" class="project-link">CI/CD Pipeline Overhaul</a></td>
                 <td class="table-td text-slate-400 hidden sm:table-cell">T. Holm</td>
-                <td class="table-td text-slate-400 hidden md:table-cell">01/27/2026</td>
-                <td class="table-td text-slate-400 hidden md:table-cell">03/06/2026</td>
-                <td class="table-td hidden lg:table-cell">
-                  <div class="flex items-center gap-2">
-                    <div class="flex-1 h-1.5 bg-slate-700 rounded-full overflow-hidden min-w-16">
-                      <div class="h-full bg-emerald-500 rounded-full" style="width:88%"></div>
+                <td class="table-td">
+                  <div class="flex items-center justify-center gap-1.5">
+                    <div class="w-16 h-1.5 bg-slate-700 rounded-full overflow-hidden">
+                      <div class="h-full bg-emerald-500" style="width:88%"></div>
                     </div>
                     <span class="text-xs text-slate-400 w-8 text-right">88%</span>
                   </div>
                 </td>
-                <td class="table-td"><span class="status-badge status-badge-green">On Track</span></td>
-                <td class="table-td text-right text-slate-300 hidden sm:table-cell">$67,000</td>
-                <td class="table-td hidden xl:table-cell">
-                  <div class="gantt-track"><div class="gantt-fill bg-emerald-500/70" style="margin-left:22%;width:30%"></div></div>
-                </td>
+                <td class="table-td text-center"><span class="status-badge status-badge-green">On Track</span></td>
+                <td class="table-td text-right text-slate-300 hidden md:table-cell">$67K</td>
               </tr>
 
-              <!-- Row 7: Mobile App v3.0 -->
+              <!-- Row 7 -->
               <tr class="table-row">
-                <td class="table-td text-center"><input type="checkbox" class="rounded border-slate-600 bg-slate-700 text-indigo-500 focus:ring-indigo-500 focus:ring-offset-slate-900 cursor-pointer"></td>
-                <td class="table-td"><span class="status-dot status-dot-amber"></span></td>
                 <td class="table-td font-medium"><a href="#" class="project-link">Mobile App v3.0</a></td>
                 <td class="table-td text-slate-400 hidden sm:table-cell">L. Poulsen</td>
-                <td class="table-td text-slate-400 hidden md:table-cell">02/10/2026</td>
-                <td class="table-td text-slate-400 hidden md:table-cell">05/22/2026</td>
-                <td class="table-td hidden lg:table-cell">
-                  <div class="flex items-center gap-2">
-                    <div class="flex-1 h-1.5 bg-slate-700 rounded-full overflow-hidden min-w-16">
-                      <div class="h-full bg-amber-500 rounded-full" style="width:15%"></div>
+                <td class="table-td">
+                  <div class="flex items-center justify-center gap-1.5">
+                    <div class="w-16 h-1.5 bg-slate-700 rounded-full overflow-hidden">
+                      <div class="h-full bg-amber-500" style="width:15%"></div>
                     </div>
                     <span class="text-xs text-slate-400 w-8 text-right">15%</span>
                   </div>
                 </td>
-                <td class="table-td"><span class="status-badge status-badge-amber">At Risk</span></td>
-                <td class="table-td text-right text-slate-300 hidden sm:table-cell">$410,000</td>
-                <td class="table-td hidden xl:table-cell">
-                  <div class="gantt-track"><div class="gantt-fill bg-amber-500/70" style="margin-left:35%;width:60%"></div></div>
-                </td>
+                <td class="table-td text-center"><span class="status-badge status-badge-amber">At Risk</span></td>
+                <td class="table-td text-right text-slate-300 hidden md:table-cell">$410K</td>
               </tr>
 
-              <!-- Row 8: Security Audit & Compliance -->
+              <!-- Row 8 -->
               <tr class="table-row">
-                <td class="table-td text-center"><input type="checkbox" class="rounded border-slate-600 bg-slate-700 text-indigo-500 focus:ring-indigo-500 focus:ring-offset-slate-900 cursor-pointer"></td>
-                <td class="table-td"><span class="status-dot status-dot-green"></span></td>
                 <td class="table-td font-medium"><a href="#" class="project-link">Security Audit &amp; Compliance</a></td>
                 <td class="table-td text-slate-400 hidden sm:table-cell">A. Krogh</td>
-                <td class="table-td text-slate-400 hidden md:table-cell">01/06/2026</td>
-                <td class="table-td text-slate-400 hidden md:table-cell">02/21/2026</td>
-                <td class="table-td hidden lg:table-cell">
-                  <div class="flex items-center gap-2">
-                    <div class="flex-1 h-1.5 bg-slate-700 rounded-full overflow-hidden min-w-16">
-                      <div class="h-full bg-emerald-500 rounded-full" style="width:95%"></div>
+                <td class="table-td">
+                  <div class="flex items-center justify-center gap-1.5">
+                    <div class="w-16 h-1.5 bg-slate-700 rounded-full overflow-hidden">
+                      <div class="h-full bg-emerald-500" style="width:95%"></div>
                     </div>
                     <span class="text-xs text-slate-400 w-8 text-right">95%</span>
                   </div>
                 </td>
-                <td class="table-td"><span class="status-badge status-badge-green">On Track</span></td>
-                <td class="table-td text-right text-slate-300 hidden sm:table-cell">$52,000</td>
-                <td class="table-td hidden xl:table-cell">
-                  <div class="gantt-track"><div class="gantt-fill bg-indigo-500/70" style="margin-left:10%;width:35%"></div></div>
-                </td>
+                <td class="table-td text-center"><span class="status-badge status-badge-green">On Track</span></td>
+                <td class="table-td text-right text-slate-300 hidden md:table-cell">$52K</td>
               </tr>
 
             </tbody>
           </table>
-        </div>
-
-        <!-- Table footer / pagination -->
-        <div class="px-5 py-3 border-t border-slate-700/60 flex items-center justify-between text-xs text-slate-500">
-          <span>Showing 1 – 8 of 8 projects</span>
-          <div class="flex items-center gap-1">
-            <button class="px-2 py-1 rounded hover:bg-slate-700 hover:text-white transition-colors duration-150">&laquo; First</button>
-            <button class="px-2 py-1 rounded hover:bg-slate-700 hover:text-white transition-colors duration-150">&lsaquo; Prev</button>
-            <button class="px-2.5 py-1 rounded bg-indigo-600 text-white font-medium">1</button>
-            <button class="px-2 py-1 rounded hover:bg-slate-700 hover:text-white transition-colors duration-150">Next &rsaquo;</button>
-            <button class="px-2 py-1 rounded hover:bg-slate-700 hover:text-white transition-colors duration-150">Last &raquo;</button>
-          </div>
         </div>
       </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -25,19 +25,19 @@
   </script>
   <link rel="stylesheet" href="styles.css">
 </head>
-<body class="bg-slate-900 text-slate-100 min-h-screen flex flex-col">
+<body class="bg-slate-950 text-slate-100 min-h-screen flex flex-col">
 
   <!-- ╔══════════════════════════════════════════════════════╗ -->
   <!-- ║  STICKY HEADER                                       ║ -->
   <!-- ╚══════════════════════════════════════════════════════╝ -->
-  <header id="site-header" class="sticky top-0 z-50 bg-slate-900 border-b border-slate-700/60">
-    <div class="flex items-center justify-between px-4 lg:px-6 h-16">
+  <header id="site-header" class="sticky top-0 z-50 bg-slate-900/95 backdrop-blur border-b border-slate-700/30">
+    <div class="flex items-center justify-between px-4 lg:px-8 h-14">
 
       <!-- Logo + Brand -->
-      <div class="flex items-center gap-3">
+      <div class="flex items-center gap-3 min-w-0">
         <!-- Hamburger (mobile) -->
         <button id="sidebar-toggle"
-          class="lg:hidden p-1.5 rounded-md text-slate-400 hover:text-white hover:bg-slate-700 transition-colors duration-150"
+          class="lg:hidden p-1 rounded-md text-slate-400 hover:text-white hover:bg-slate-800 transition-colors duration-150"
           aria-label="Toggle sidebar">
           <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16"/>
@@ -45,55 +45,23 @@
         </button>
 
         <!-- Brand mark -->
-        <div class="flex items-center gap-2.5">
-          <div class="w-7 h-7 rounded-lg bg-indigo-600 flex items-center justify-center flex-shrink-0">
-            <svg class="w-4 h-4 text-white" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M3 7a2 2 0 012-2h3l2 3H3V7zm0 0v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-7L10 4H5a2 2 0 00-2 3z"/>
-            </svg>
+        <div class="flex items-center gap-2 min-w-0">
+          <div class="w-6 h-6 rounded-lg bg-gradient-to-br from-indigo-500 to-indigo-600 flex items-center justify-center flex-shrink-0">
+            <svg class="w-3.5 h-3.5 text-white" fill="currentColor" viewBox="0 0 20 20"><path d="M2 6a2 2 0 012-2h12a2 2 0 012 2v8a2 2 0 01-2 2H4a2 2 0 01-2-2V6z"/></svg>
           </div>
-          <span class="font-semibold text-white text-sm tracking-wide">Contoso <span class="text-indigo-400">Projects</span></span>
+          <span class="font-semibold text-white text-sm tracking-tight whitespace-nowrap">Contoso</span>
         </div>
       </div>
 
-      <!-- Top nav tabs (hidden on mobile) -->
-      <nav class="hidden md:flex items-center gap-1" role="navigation" aria-label="Main navigation">
-        <a href="#" class="nav-tab nav-tab-active" data-nav="project-center">Project Center</a>
-        <a href="#" class="nav-tab">Resource Center</a>
-        <a href="#" class="nav-tab">Status Reports</a>
-        <a href="#" class="nav-tab">Documents</a>
-        <a href="#" class="nav-tab">Issues &amp; Risks</a>
-        <a href="#" class="nav-tab">Admin</a>
-      </nav>
-
       <!-- User area -->
-      <div class="flex items-center gap-3">
-        <!-- Notification bell -->
-        <button class="relative p-1.5 rounded-md text-slate-400 hover:text-white hover:bg-slate-700 transition-colors duration-150" aria-label="Notifications">
-          <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6 6 0 10-12 0v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"/>
-          </svg>
-          <span class="absolute top-1 right-1 w-2 h-2 bg-indigo-500 rounded-full"></span>
-        </button>
-
+      <div class="flex items-center gap-4 md:gap-6">
         <!-- User avatar -->
-        <div class="flex items-center gap-2 cursor-pointer group">
-          <div class="w-7 h-7 rounded-full bg-gradient-to-br from-indigo-500 to-violet-600 flex items-center justify-center text-xs font-bold text-white select-none">EW</div>
-          <div class="hidden sm:block">
-            <p class="text-xs font-medium text-white leading-none">E. Wiberg</p>
-            <p class="text-xs text-slate-400 leading-none mt-0.5">CONTOSO\ewiberg</p>
+        <div class="flex items-center gap-2 cursor-pointer">
+          <div class="w-6 h-6 rounded-full bg-gradient-to-br from-indigo-500 to-violet-600 flex items-center justify-center text-xs font-bold text-white select-none flex-shrink-0">EW</div>
+          <div class="hidden sm:block min-w-0">
+            <p class="text-xs font-medium text-white leading-tight">E. Wiberg</p>
           </div>
-          <svg class="hidden sm:block w-3.5 h-3.5 text-slate-400 group-hover:text-white transition-colors duration-150" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/>
-          </svg>
         </div>
-
-        <!-- Sign out link -->
-        <a href="#" class="hidden sm:inline-flex items-center gap-1.5 text-xs text-slate-400 hover:text-white transition-colors duration-150 px-2 py-1 rounded hover:bg-slate-700">
-          <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"/>
-          </svg>
-          Sign Out
-        </a>
       </div>
     </div>
   </header>
@@ -105,39 +73,31 @@
 
     <!-- ── SIDEBAR ───────────────────────────────────────────── -->
     <aside id="sidebar"
-      class="sidebar-panel w-56 flex-shrink-0 bg-slate-900 border-r border-slate-700/60 flex flex-col overflow-y-auto
+      class="sidebar-panel w-48 flex-shrink-0 bg-slate-900/50 border-r border-slate-700/30 flex flex-col overflow-y-auto
              fixed inset-y-0 top-14 left-0 z-40 transform -translate-x-full transition-transform duration-200 ease-in-out
              lg:static lg:translate-x-0 lg:top-auto lg:inset-y-auto lg:z-auto lg:transition-none">
 
-      <div class="px-3 pt-4 pb-6 flex flex-col gap-4 flex-1">
+      <div class="px-2 pt-6 pb-4 flex flex-col gap-1 flex-1">
 
         <!-- Navigation section -->
         <nav class="flex flex-col gap-0.5">
           <a href="#" class="sidebar-link sidebar-link-active">
-            <svg class="sidebar-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 10h16M4 14h16M4 18h16"/></svg>
-            Project Center
+            <svg class="sidebar-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V7M3 7a2 2 0 012-2h14a2 2 0 012 2"/></svg>
+            <span>Projects</span>
           </a>
           <a href="#" class="sidebar-link">
             <svg class="sidebar-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/></svg>
-            Reports
+            <span>Reports</span>
           </a>
           <a href="#" class="sidebar-link">
             <svg class="sidebar-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0"/></svg>
-            Resources
+            <span>Resources</span>
           </a>
           <a href="#" class="sidebar-link">
             <svg class="sidebar-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/></svg>
-            My Tasks
+            <span>Tasks</span>
           </a>
         </nav>
-      </div>
-
-      <!-- Sidebar footer -->
-      <div class="px-3 py-3 border-t border-slate-700/60">
-        <a href="#" class="sidebar-link text-slate-500 hover:text-slate-300">
-          <svg class="sidebar-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/></svg>
-          Recycle Bin
-        </a>
       </div>
     </aside>
 
@@ -147,95 +107,91 @@
       aria-hidden="true"></div>
 
     <!-- ── MAIN CONTENT ──────────────────────────────────────── -->
-    <main class="flex-1 overflow-y-auto p-4 lg:p-6 min-w-0">
+    <main class="flex-1 overflow-y-auto min-w-0 bg-gradient-to-b from-slate-950 to-slate-900">
+      <div class="p-6 lg:p-8 max-w-7xl mx-auto w-full">
 
       <!-- Page heading -->
-      <div class="mb-6 animate-fade-in">
-        <h1 class="text-2xl font-bold text-white tracking-tight">Project Center</h1>
-        <p class="text-slate-400 text-sm mt-1">All Projects &amp; Portfolio Overview</p>
+      <div class="mb-8">
+        <h1 class="text-3xl font-bold text-white tracking-tight">Project Center</h1>
+        <p class="text-slate-400 text-sm mt-2">Manage and monitor all active and archived projects</p>
       </div>
 
       <!-- ══════════════════════════════════════════════════════ -->
-      <!-- KPI SUMMARY CARDS                                    -->
+      <!-- KPI SUMMARY CARDS (3 columns)                        -->
       <!-- ══════════════════════════════════════════════════════ -->
-      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-6 animate-fade-in" style="animation-delay:0.05s">
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
 
         <!-- Total Projects -->
         <div class="kpi-card">
-          <div class="flex items-start justify-between mb-2">
-            <p class="text-xs font-semibold text-slate-400 uppercase tracking-wide">Total Projects</p>
-            <div class="kpi-icon bg-indigo-500/20 text-indigo-400">
-              <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M3 7a2 2 0 012-2h3l2 3H3V7zm0 0v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-7L10 4H5a2 2 0 00-2 3z"/></svg>
+          <div class="flex items-start justify-between">
+            <div>
+              <p class="text-xs font-semibold text-slate-400 uppercase tracking-wide">Total Projects</p>
+              <p class="text-4xl font-bold text-white mt-3">8</p>
+              <p class="text-sm text-slate-400 mt-3">Active portfolio</p>
+            </div>
+            <div class="kpi-icon bg-indigo-500/20 text-indigo-400 mt-1">
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V7M3 7a2 2 0 012-2h14a2 2 0 012 2"/></svg>
             </div>
           </div>
-          <p class="text-3xl font-bold text-white">8</p>
-          <p class="text-xs text-slate-500 mt-1">Active portfolio</p>
         </div>
 
         <!-- On Track -->
         <div class="kpi-card">
-          <div class="flex items-start justify-between mb-2">
-            <p class="text-xs font-semibold text-slate-400 uppercase tracking-wide">On Track</p>
-            <div class="kpi-icon bg-emerald-500/20 text-emerald-400">
-              <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+          <div class="flex items-start justify-between">
+            <div>
+              <p class="text-xs font-semibold text-slate-400 uppercase tracking-wide">On Track</p>
+              <p class="text-4xl font-bold text-emerald-400 mt-3">5</p>
+              <p class="text-sm text-slate-400 mt-3">62.5% of portfolio</p>
+            </div>
+            <div class="kpi-icon bg-emerald-500/20 text-emerald-400 mt-1">
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
             </div>
           </div>
-          <p class="text-3xl font-bold text-emerald-400">5</p>
-          <p class="text-xs text-slate-500 mt-1">62.5% of portfolio</p>
         </div>
 
-        <!-- At Risk -->
+        <!-- At Risk / Critical -->
         <div class="kpi-card">
-          <div class="flex items-start justify-between mb-2">
-            <p class="text-xs font-semibold text-slate-400 uppercase tracking-wide">At Risk</p>
-            <div class="kpi-icon bg-amber-500/20 text-amber-400">
-              <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/></svg>
+          <div class="flex items-start justify-between">
+            <div>
+              <p class="text-xs font-semibold text-slate-400 uppercase tracking-wide">Needs Attention</p>
+              <p class="text-4xl font-bold text-amber-400 mt-3">3</p>
+              <p class="text-sm text-slate-400 mt-3">2 at risk • 1 overdue</p>
+            </div>
+            <div class="kpi-icon bg-amber-500/20 text-amber-400 mt-1">
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/></svg>
             </div>
           </div>
-          <p class="text-3xl font-bold text-amber-400">2</p>
-          <p class="text-xs text-slate-500 mt-1">Needs attention</p>
         </div>
 
-        <!-- Critical / Overdue -->
-        <div class="kpi-card">
-          <div class="flex items-start justify-between mb-2">
-            <p class="text-xs font-semibold text-slate-400 uppercase tracking-wide">Critical</p>
-            <div class="kpi-icon bg-red-500/20 text-red-400">
-              <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
-            </div>
-          </div>
-          <p class="text-3xl font-bold text-red-400">1</p>
-          <p class="text-xs text-slate-500 mt-1">Overdue</p>
-        </div>
       </div>
 
       <!-- ══════════════════════════════════════════════════════ -->
       <!-- PROJECTS TABLE CARD                                  -->
       <!-- ══════════════════════════════════════════════════════ -->
-      <div class="data-card mb-6 animate-fade-in" style="animation-delay:0.10s">
-        <div class="px-6 py-4 border-b border-slate-700/60">
-          <h2 class="text-base font-semibold text-white">All Projects (8)</h2>
+      <div class="data-card mb-8">
+        <div class="px-6 py-5 border-b border-slate-700/40">
+          <h2 class="text-lg font-semibold text-white">All Projects</h2>
         </div>
 
         <!-- Scrollable table wrapper -->
         <div class="overflow-x-auto">
           <table class="w-full text-sm">
             <thead>
-              <tr class="border-b border-slate-700/60">
-                <th class="table-th text-left">Project</th>
-                <th class="table-th text-left hidden sm:table-cell">Owner</th>
-                <th class="table-th text-center">Progress</th>
-                <th class="table-th text-center">Status</th>
-                <th class="table-th text-right hidden md:table-cell">Budget</th>
+              <tr>
+                <th class="text-left">Project</th>
+                <th class="text-left hidden sm:table-cell">Owner</th>
+                <th class="text-center">Progress</th>
+                <th class="text-center">Status</th>
+                <th class="text-right hidden md:table-cell">Budget</th>
               </tr>
             </thead>
-            <tbody class="divide-y divide-slate-700/40">
+            <tbody>
 
               <!-- Row 1 -->
-              <tr class="table-row">
-                <td class="table-td font-medium"><a href="#" class="project-link">Q1 2026 Platform Modernization</a></td>
-                <td class="table-td text-slate-400 hidden sm:table-cell">E. Wiberg</td>
-                <td class="table-td">
+              <tr>
+                <td class="font-medium"><a href="#" class="project-link">Q1 2026 Platform Modernization</a></td>
+                <td class="text-slate-400 hidden sm:table-cell">E. Wiberg</td>
+                <td>
                   <div class="flex items-center justify-center gap-1.5">
                     <div class="w-16 h-1.5 bg-slate-700 rounded-full overflow-hidden">
                       <div class="h-full bg-emerald-500" style="width:72%"></div>
@@ -243,15 +199,15 @@
                     <span class="text-xs text-slate-400 w-8 text-right">72%</span>
                   </div>
                 </td>
-                <td class="table-td text-center"><span class="status-badge status-badge-green">On Track</span></td>
-                <td class="table-td text-right text-slate-300 hidden md:table-cell">$245K</td>
+                <td class="text-center"><span class="status-badge status-badge-green">On Track</span></td>
+                <td class="text-right text-slate-300 hidden md:table-cell">$245K</td>
               </tr>
 
               <!-- Row 2 -->
-              <tr class="table-row">
-                <td class="table-td font-medium"><a href="#" class="project-link">API Gateway Migration</a></td>
-                <td class="table-td text-slate-400 hidden sm:table-cell">K. Jensen</td>
-                <td class="table-td">
+              <tr>
+                <td class="font-medium"><a href="#" class="project-link">API Gateway Migration</a></td>
+                <td class="text-slate-400 hidden sm:table-cell">K. Jensen</td>
+                <td>
                   <div class="flex items-center justify-center gap-1.5">
                     <div class="w-16 h-1.5 bg-slate-700 rounded-full overflow-hidden">
                       <div class="h-full bg-indigo-500" style="width:100%"></div>
@@ -259,15 +215,15 @@
                     <span class="text-xs text-slate-400 w-8 text-right">100%</span>
                   </div>
                 </td>
-                <td class="table-td text-center"><span class="status-badge status-badge-indigo">Complete</span></td>
-                <td class="table-td text-right text-slate-300 hidden md:table-cell">$89K</td>
+                <td class="text-center"><span class="status-badge status-badge-indigo">Complete</span></td>
+                <td class="text-right text-slate-300 hidden md:table-cell">$89K</td>
               </tr>
 
               <!-- Row 3 -->
-              <tr class="table-row">
-                <td class="table-td font-medium"><a href="#" class="project-link">Customer Portal Redesign</a></td>
-                <td class="table-td text-slate-400 hidden sm:table-cell">M. Andersen</td>
-                <td class="table-td">
+              <tr>
+                <td class="font-medium"><a href="#" class="project-link">Customer Portal Redesign</a></td>
+                <td class="text-slate-400 hidden sm:table-cell">M. Andersen</td>
+                <td>
                   <div class="flex items-center justify-center gap-1.5">
                     <div class="w-16 h-1.5 bg-slate-700 rounded-full overflow-hidden">
                       <div class="h-full bg-amber-500" style="width:45%"></div>
@@ -275,15 +231,15 @@
                     <span class="text-xs text-slate-400 w-8 text-right">45%</span>
                   </div>
                 </td>
-                <td class="table-td text-center"><span class="status-badge status-badge-amber">At Risk</span></td>
-                <td class="table-td text-right text-slate-300 hidden md:table-cell">$178K</td>
+                <td class="text-center"><span class="status-badge status-badge-amber">At Risk</span></td>
+                <td class="text-right text-slate-300 hidden md:table-cell">$178K</td>
               </tr>
 
               <!-- Row 4 -->
-              <tr class="table-row">
-                <td class="table-td font-medium"><a href="#" class="project-link">Data Warehouse ETL Pipeline</a></td>
-                <td class="table-td text-slate-400 hidden sm:table-cell">S. Larsen</td>
-                <td class="table-td">
+              <tr>
+                <td class="font-medium"><a href="#" class="project-link">Data Warehouse ETL Pipeline</a></td>
+                <td class="text-slate-400 hidden sm:table-cell">S. Larsen</td>
+                <td>
                   <div class="flex items-center justify-center gap-1.5">
                     <div class="w-16 h-1.5 bg-slate-700 rounded-full overflow-hidden">
                       <div class="h-full bg-emerald-500" style="width:30%"></div>
@@ -291,15 +247,15 @@
                     <span class="text-xs text-slate-400 w-8 text-right">30%</span>
                   </div>
                 </td>
-                <td class="table-td text-center"><span class="status-badge status-badge-green">On Track</span></td>
-                <td class="table-td text-right text-slate-300 hidden md:table-cell">$156K</td>
+                <td class="text-center"><span class="status-badge status-badge-green">On Track</span></td>
+                <td class="text-right text-slate-300 hidden md:table-cell">$156K</td>
               </tr>
 
               <!-- Row 5 -->
-              <tr class="table-row">
-                <td class="table-td font-medium"><a href="#" class="project-link">Legacy CRM Data Migration</a></td>
-                <td class="table-td text-slate-400 hidden sm:table-cell">P. Nielsen</td>
-                <td class="table-td">
+              <tr>
+                <td class="font-medium"><a href="#" class="project-link">Legacy CRM Data Migration</a></td>
+                <td class="text-slate-400 hidden sm:table-cell">P. Nielsen</td>
+                <td>
                   <div class="flex items-center justify-center gap-1.5">
                     <div class="w-16 h-1.5 bg-slate-700 rounded-full overflow-hidden">
                       <div class="h-full bg-red-500" style="width:58%"></div>
@@ -307,15 +263,15 @@
                     <span class="text-xs text-slate-400 w-8 text-right">58%</span>
                   </div>
                 </td>
-                <td class="table-td text-center"><span class="status-badge status-badge-red">OVERDUE</span></td>
-                <td class="table-td text-right text-slate-300 hidden md:table-cell">$320K</td>
+                <td class="text-center"><span class="status-badge status-badge-red">OVERDUE</span></td>
+                <td class="text-right text-slate-300 hidden md:table-cell">$320K</td>
               </tr>
 
               <!-- Row 6 -->
-              <tr class="table-row">
-                <td class="table-td font-medium"><a href="#" class="project-link">CI/CD Pipeline Overhaul</a></td>
-                <td class="table-td text-slate-400 hidden sm:table-cell">T. Holm</td>
-                <td class="table-td">
+              <tr>
+                <td class="font-medium"><a href="#" class="project-link">CI/CD Pipeline Overhaul</a></td>
+                <td class="text-slate-400 hidden sm:table-cell">T. Holm</td>
+                <td>
                   <div class="flex items-center justify-center gap-1.5">
                     <div class="w-16 h-1.5 bg-slate-700 rounded-full overflow-hidden">
                       <div class="h-full bg-emerald-500" style="width:88%"></div>
@@ -323,15 +279,15 @@
                     <span class="text-xs text-slate-400 w-8 text-right">88%</span>
                   </div>
                 </td>
-                <td class="table-td text-center"><span class="status-badge status-badge-green">On Track</span></td>
-                <td class="table-td text-right text-slate-300 hidden md:table-cell">$67K</td>
+                <td class="text-center"><span class="status-badge status-badge-green">On Track</span></td>
+                <td class="text-right text-slate-300 hidden md:table-cell">$67K</td>
               </tr>
 
               <!-- Row 7 -->
-              <tr class="table-row">
-                <td class="table-td font-medium"><a href="#" class="project-link">Mobile App v3.0</a></td>
-                <td class="table-td text-slate-400 hidden sm:table-cell">L. Poulsen</td>
-                <td class="table-td">
+              <tr>
+                <td class="font-medium"><a href="#" class="project-link">Mobile App v3.0</a></td>
+                <td class="text-slate-400 hidden sm:table-cell">L. Poulsen</td>
+                <td>
                   <div class="flex items-center justify-center gap-1.5">
                     <div class="w-16 h-1.5 bg-slate-700 rounded-full overflow-hidden">
                       <div class="h-full bg-amber-500" style="width:15%"></div>
@@ -339,15 +295,15 @@
                     <span class="text-xs text-slate-400 w-8 text-right">15%</span>
                   </div>
                 </td>
-                <td class="table-td text-center"><span class="status-badge status-badge-amber">At Risk</span></td>
-                <td class="table-td text-right text-slate-300 hidden md:table-cell">$410K</td>
+                <td class="text-center"><span class="status-badge status-badge-amber">At Risk</span></td>
+                <td class="text-right text-slate-300 hidden md:table-cell">$410K</td>
               </tr>
 
               <!-- Row 8 -->
-              <tr class="table-row">
-                <td class="table-td font-medium"><a href="#" class="project-link">Security Audit &amp; Compliance</a></td>
-                <td class="table-td text-slate-400 hidden sm:table-cell">A. Krogh</td>
-                <td class="table-td">
+              <tr>
+                <td class="font-medium"><a href="#" class="project-link">Security Audit &amp; Compliance</a></td>
+                <td class="text-slate-400 hidden sm:table-cell">A. Krogh</td>
+                <td>
                   <div class="flex items-center justify-center gap-1.5">
                     <div class="w-16 h-1.5 bg-slate-700 rounded-full overflow-hidden">
                       <div class="h-full bg-emerald-500" style="width:95%"></div>
@@ -355,8 +311,8 @@
                     <span class="text-xs text-slate-400 w-8 text-right">95%</span>
                   </div>
                 </td>
-                <td class="table-td text-center"><span class="status-badge status-badge-green">On Track</span></td>
-                <td class="table-td text-right text-slate-300 hidden md:table-cell">$52K</td>
+                <td class="text-center"><span class="status-badge status-badge-green">On Track</span></td>
+                <td class="text-right text-slate-300 hidden md:table-cell">$52K</td>
               </tr>
 
             </tbody>
@@ -367,113 +323,110 @@
       <!-- ══════════════════════════════════════════════════════ -->
       <!-- RESOURCE ALLOCATION TABLE                            -->
       <!-- ══════════════════════════════════════════════════════ -->
-      <div class="data-card mb-6 animate-fade-in" style="animation-delay:0.15s">
-        <div class="px-5 py-4 border-b border-slate-700/60 flex items-center gap-2">
-          <svg class="w-4 h-4 text-indigo-400 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0"/>
-          </svg>
-          <h2 class="text-sm font-semibold text-white">Resource Allocation Summary</h2>
+      <div class="data-card mb-8">
+        <div class="px-6 py-5 border-b border-slate-700/40">
+          <h2 class="text-lg font-semibold text-white">Resource Allocation</h2>
         </div>
 
         <div class="overflow-x-auto">
           <table class="w-full text-sm">
             <thead>
-              <tr class="border-b border-slate-700/60">
-                <th class="table-th text-left">Resource</th>
-                <th class="table-th text-left hidden sm:table-cell">Department</th>
-                <th class="table-th text-right">Allocated Hrs</th>
-                <th class="table-th text-right hidden sm:table-cell">Available Hrs</th>
-                <th class="table-th text-left">Utilization</th>
+              <tr>
+                <th class="text-left">Resource</th>
+                <th class="text-left hidden sm:table-cell">Department</th>
+                <th class="text-right">Allocated Hrs</th>
+                <th class="text-right hidden sm:table-cell">Available Hrs</th>
+                <th class="text-left">Utilization</th>
               </tr>
             </thead>
-            <tbody class="divide-y divide-slate-700/40">
+            <tbody>
 
-              <tr class="table-row">
-                <td class="table-td font-medium text-slate-200">E. Wiberg</td>
-                <td class="table-td text-slate-400 hidden sm:table-cell">Engineering</td>
-                <td class="table-td text-right text-slate-300">148</td>
-                <td class="table-td text-right text-slate-400 hidden sm:table-cell">160</td>
-                <td class="table-td">
+              <tr>
+                <td class="font-medium text-slate-200">E. Wiberg</td>
+                <td class="text-slate-400 hidden sm:table-cell">Engineering</td>
+                <td class="text-right text-slate-300">148</td>
+                <td class="text-right text-slate-400 hidden sm:table-cell">160</td>
+                <td>
                   <div class="flex items-center gap-2">
                     <div class="w-20 h-1.5 bg-slate-700 rounded-full overflow-hidden">
                       <div class="h-full bg-amber-500 rounded-full" style="width:93%"></div>
                     </div>
-                    <span class="util-badge util-badge-high">93%</span>
+                    <span class="text-xs font-medium text-amber-300">93%</span>
                   </div>
                 </td>
               </tr>
 
-              <tr class="table-row">
-                <td class="table-td font-medium text-slate-200">K. Jensen</td>
-                <td class="table-td text-slate-400 hidden sm:table-cell">Engineering</td>
-                <td class="table-td text-right text-slate-300">120</td>
-                <td class="table-td text-right text-slate-400 hidden sm:table-cell">160</td>
-                <td class="table-td">
+              <tr>
+                <td class="font-medium text-slate-200">K. Jensen</td>
+                <td class="text-slate-400 hidden sm:table-cell">Engineering</td>
+                <td class="text-right text-slate-300">120</td>
+                <td class="text-right text-slate-400 hidden sm:table-cell">160</td>
+                <td>
                   <div class="flex items-center gap-2">
                     <div class="w-20 h-1.5 bg-slate-700 rounded-full overflow-hidden">
                       <div class="h-full bg-emerald-500 rounded-full" style="width:75%"></div>
                     </div>
-                    <span class="util-badge util-badge-med">75%</span>
+                    <span class="text-xs font-medium text-emerald-300">75%</span>
                   </div>
                 </td>
               </tr>
 
-              <tr class="table-row">
-                <td class="table-td font-medium text-slate-200">M. Andersen</td>
-                <td class="table-td text-slate-400 hidden sm:table-cell">Design</td>
-                <td class="table-td text-right text-slate-300">155</td>
-                <td class="table-td text-right text-slate-400 hidden sm:table-cell">160</td>
-                <td class="table-td">
+              <tr>
+                <td class="font-medium text-slate-200">M. Andersen</td>
+                <td class="text-slate-400 hidden sm:table-cell">Design</td>
+                <td class="text-right text-slate-300">155</td>
+                <td class="text-right text-slate-400 hidden sm:table-cell">160</td>
+                <td>
                   <div class="flex items-center gap-2">
                     <div class="w-20 h-1.5 bg-slate-700 rounded-full overflow-hidden">
                       <div class="h-full bg-red-500 rounded-full" style="width:97%"></div>
                     </div>
-                    <span class="util-badge util-badge-over">97%</span>
+                    <span class="text-xs font-medium text-red-300">97%</span>
                   </div>
                 </td>
               </tr>
 
-              <tr class="table-row">
-                <td class="table-td font-medium text-slate-200">S. Larsen</td>
-                <td class="table-td text-slate-400 hidden sm:table-cell">Data</td>
-                <td class="table-td text-right text-slate-300">136</td>
-                <td class="table-td text-right text-slate-400 hidden sm:table-cell">160</td>
-                <td class="table-td">
+              <tr>
+                <td class="font-medium text-slate-200">S. Larsen</td>
+                <td class="text-slate-400 hidden sm:table-cell">Data</td>
+                <td class="text-right text-slate-300">136</td>
+                <td class="text-right text-slate-400 hidden sm:table-cell">160</td>
+                <td>
                   <div class="flex items-center gap-2">
                     <div class="w-20 h-1.5 bg-slate-700 rounded-full overflow-hidden">
                       <div class="h-full bg-amber-500 rounded-full" style="width:85%"></div>
                     </div>
-                    <span class="util-badge util-badge-high">85%</span>
+                    <span class="text-xs font-medium text-amber-300">85%</span>
                   </div>
                 </td>
               </tr>
 
-              <tr class="table-row">
-                <td class="table-td font-medium text-slate-200">P. Nielsen</td>
-                <td class="table-td text-slate-400 hidden sm:table-cell">Engineering</td>
-                <td class="table-td text-right text-slate-300">160</td>
-                <td class="table-td text-right text-slate-400 hidden sm:table-cell">160</td>
-                <td class="table-td">
+              <tr>
+                <td class="font-medium text-slate-200">P. Nielsen</td>
+                <td class="text-slate-400 hidden sm:table-cell">Engineering</td>
+                <td class="text-right text-slate-300">160</td>
+                <td class="text-right text-slate-400 hidden sm:table-cell">160</td>
+                <td>
                   <div class="flex items-center gap-2">
                     <div class="w-20 h-1.5 bg-slate-700 rounded-full overflow-hidden">
                       <div class="h-full bg-red-500 rounded-full" style="width:100%"></div>
                     </div>
-                    <span class="util-badge util-badge-over">100%</span>
+                    <span class="text-xs font-medium text-red-300">100%</span>
                   </div>
                 </td>
               </tr>
 
-              <tr class="table-row">
-                <td class="table-td font-medium text-slate-200">T. Holm</td>
-                <td class="table-td text-slate-400 hidden sm:table-cell">DevOps</td>
-                <td class="table-td text-right text-slate-300">112</td>
-                <td class="table-td text-right text-slate-400 hidden sm:table-cell">160</td>
-                <td class="table-td">
+              <tr>
+                <td class="font-medium text-slate-200">T. Holm</td>
+                <td class="text-slate-400 hidden sm:table-cell">DevOps</td>
+                <td class="text-right text-slate-300">112</td>
+                <td class="text-right text-slate-400 hidden sm:table-cell">160</td>
+                <td>
                   <div class="flex items-center gap-2">
                     <div class="w-20 h-1.5 bg-slate-700 rounded-full overflow-hidden">
                       <div class="h-full bg-emerald-500 rounded-full" style="width:70%"></div>
                     </div>
-                    <span class="util-badge util-badge-med">70%</span>
+                    <span class="text-xs font-medium text-emerald-300">70%</span>
                   </div>
                 </td>
               </tr>
@@ -486,15 +439,13 @@
       <!-- ══════════════════════════════════════════════════════ -->
       <!-- PAGE FOOTER                                          -->
       <!-- ══════════════════════════════════════════════════════ -->
-      <footer class="border-t border-slate-700/60 pt-4 pb-6 mt-2">
-        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 text-xs text-slate-500">
-          <span>Microsoft Office Project Server 2005 &copy; Microsoft Corporation. All rights reserved.</span>
-          <div class="flex items-center gap-3">
-            <a href="#" class="hover:text-slate-300 transition-colors duration-150">Privacy Statement</a>
-            <span class="text-slate-700">|</span>
-            <a href="#" class="hover:text-slate-300 transition-colors duration-150">Terms of Use</a>
-            <span class="text-slate-700">|</span>
-            <a href="#" class="hover:text-slate-300 transition-colors duration-150">Contact Admin</a>
+      <footer class="border-t border-slate-700/30 pt-6 pb-8 mt-12">
+        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 text-xs text-slate-500">
+          <span>Contoso Ltd — Project Center. All rights reserved.</span>
+          <div class="flex items-center gap-4">
+            <a href="#" class="hover:text-slate-300 transition-colors duration-150">Privacy</a>
+            <a href="#" class="hover:text-slate-300 transition-colors duration-150">Terms</a>
+            <a href="#" class="hover:text-slate-300 transition-colors duration-150">Support</a>
           </div>
         </div>
       </footer>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,47 +1,258 @@
 /* ============================================================
    Contoso Ltd — Premium Dark SaaS Dashboard
-   Supplemental styles (Tailwind CDN handles utilities)
+   Supplemental custom styles (Tailwind CDN handles utilities)
    ============================================================ */
 
-/* ── Font import ─────────────────────────────────────────────── */
+/* ══════════════════════════════════════════════════════════════
+   FONT IMPORTS
+   ══════════════════════════════════════════════════════════════ */
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
 
-/* ── Base reset + font override ──────────────────────────────── */
-*, *::before, *::after {
-  box-sizing: border-box;
-}
-
-html {
-  scroll-behavior: smooth;
-}
-
-body {
-  font-family: Inter, system-ui, -apple-system, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-/* ── Custom scrollbar (webkit) ───────────────────────────────── */
+/* ══════════════════════════════════════════════════════════════
+   CUSTOM SCROLLBAR
+   ══════════════════════════════════════════════════════════════ */
 ::-webkit-scrollbar {
-  width: 7px;
-  height: 7px;
+  width: 8px;
+  height: 8px;
 }
 
 ::-webkit-scrollbar-track {
-  background: #0f172a;
+  background: transparent;
 }
 
 ::-webkit-scrollbar-thumb {
-  background: #334155;
-  border-radius: 3px;
+  background: rgba(71, 85, 105, 0.5);
+  border-radius: 4px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: #6366f1;
+  background: rgba(71, 85, 105, 0.7);
 }
 
-/* ── Animations ──────────────────────────────────────────────── */
-@keyframes fade-in {
+/* Firefox scrollbar */
+* {
+  scrollbar-color: rgba(71, 85, 105, 0.5) transparent;
+  scrollbar-width: thin;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   LAYOUT & STRUCTURE
+   ══════════════════════════════════════════════════════════════ */
+
+html, body {
+  height: 100%;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+}
+
+/* Header should be at top and not affected by sidebar */
+#site-header {
+  flex-shrink: 0;
+}
+
+/* Main flex container for sidebar + main */
+body > div {
+  flex: 1;
+  min-height: 0;
+}
+
+/* Sidebar styling */
+.sidebar-panel {
+  /* Fixed positioning for mobile */
+  top: 64px; /* Header height (h-16 = 64px) */
+  height: calc(100vh - 64px);
+}
+
+/* Main content should grow and scroll */
+main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  padding: 0;
+}
+
+main > div {
+  flex: 1;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   SIDEBAR STYLING
+   ══════════════════════════════════════════════════════════════ */
+.sidebar-link {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  border-radius: 0.5rem;
+  color: rgb(148, 163, 184);
+  text-decoration: none;
+  font-size: 0.9375rem;
+  transition: all 0.15s ease;
+}
+
+.sidebar-link:hover {
+  color: rgb(226, 232, 240);
+  background-color: rgba(71, 85, 105, 0.3);
+}
+
+.sidebar-link-active {
+  color: rgb(226, 232, 240);
+  background: rgba(99, 102, 241, 0.15);
+  border-left: 2px solid rgb(99, 102, 241);
+  padding-left: calc(0.75rem - 2px);
+}
+
+.sidebar-icon {
+  width: 1.25rem;
+  height: 1.25rem;
+  flex-shrink: 0;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   CARD STYLES
+   ══════════════════════════════════════════════════════════════ */
+.kpi-card,
+.data-card {
+  background: rgba(30, 41, 59, 0.4);
+  border: 1px solid rgba(71, 85, 105, 0.2);
+  border-radius: 0.75rem;
+  transition: all 0.2s ease;
+}
+
+.kpi-card:hover,
+.data-card:hover {
+  background: rgba(30, 41, 59, 0.6);
+  border-color: rgba(99, 102, 241, 0.3);
+}
+
+.kpi-card {
+  padding: 1.5rem;
+}
+
+.kpi-icon {
+  padding: 0.75rem;
+  border-radius: 0.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   TABLE STYLES
+   ══════════════════════════════════════════════════════════════ */
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+thead {
+  background: rgba(15, 23, 42, 0.5);
+  border-bottom: 1px solid rgba(71, 85, 105, 0.2);
+}
+
+th {
+  padding: 1rem;
+  text-align: left;
+  font-weight: 600;
+  font-size: 0.875rem;
+  color: rgb(148, 163, 184);
+  text-transform: uppercase;
+  letter-spacing: 0.025em;
+}
+
+td {
+  padding: 1rem;
+  border-bottom: 1px solid rgba(71, 85, 105, 0.1);
+  font-size: 0.9375rem;
+}
+
+tbody tr {
+  transition: background-color 0.15s ease;
+}
+
+tbody tr:hover {
+  background-color: rgba(71, 85, 105, 0.1);
+}
+
+/* Status badges */
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.75rem;
+  border-radius: 0.375rem;
+  font-weight: 600;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.025em;
+  white-space: nowrap;
+}
+
+.status-badge::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.status-badge-green {
+  background-color: rgba(16, 185, 129, 0.15);
+  color: rgb(16, 185, 129);
+}
+
+.status-badge-green::before {
+  background-color: rgb(16, 185, 129);
+}
+
+.status-badge-amber {
+  background-color: rgba(251, 146, 60, 0.15);
+  color: rgb(251, 146, 60);
+}
+
+.status-badge-amber::before {
+  background-color: rgb(251, 146, 60);
+}
+
+.status-badge-red {
+  background-color: rgba(239, 68, 68, 0.15);
+  color: rgb(239, 68, 68);
+}
+
+.status-badge-red::before {
+  background-color: rgb(239, 68, 68);
+}
+
+.status-badge-indigo {
+  background-color: rgba(99, 102, 241, 0.15);
+  color: rgb(99, 102, 241);
+}
+
+.status-badge-indigo::before {
+  background-color: rgb(99, 102, 241);
+}
+
+/* Project links */
+.project-link {
+  color: rgb(226, 232, 240);
+  text-decoration: none;
+  transition: color 0.15s ease;
+  font-weight: 500;
+}
+
+.project-link:hover {
+  color: rgb(99, 102, 241);
+}
+
+/* ══════════════════════════════════════════════════════════════
+   ANIMATIONS & TRANSITIONS
+   ══════════════════════════════════════════════════════════════ */
+@keyframes fadeIn {
   from {
     opacity: 0;
     transform: translateY(10px);
@@ -53,252 +264,83 @@ body {
 }
 
 .animate-fade-in {
-  animation: fade-in 0.35s ease-out both;
+  animation: fadeIn 0.3s ease-out;
 }
 
 /* ══════════════════════════════════════════════════════════════
-   SIDEBAR
+   MOBILE RESPONSIVE (≤640px)
    ══════════════════════════════════════════════════════════════ */
-.sidebar-link {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  padding: 0.625rem 0.75rem;
-  border-radius: 0.5rem;
-  font-size: 0.875rem;
-  font-weight: 500;
-  color: #94a3b8;
-  text-decoration: none;
-  transition: color 150ms ease, background-color 150ms ease;
-}
-
-.sidebar-link:hover {
-  color: #e2e8f0;
-  background-color: #1e293b;
-}
-
-.sidebar-link-active {
-  color: #c7d2fe;
-  background-color: #312e81;
-}
-
-.sidebar-link-active:hover {
-  color: #e0e7ff;
-  background-color: #3730a3;
-}
-
-.sidebar-link span {
-  flex: 1;
-}
-
-.sidebar-icon {
-  width: 1.25rem;
-  height: 1.25rem;
-  flex-shrink: 0;
-  stroke-width: 1.75;
-}
-
-/* ══════════════════════════════════════════════════════════════
-   KPI CARDS
-   ══════════════════════════════════════════════════════════════ */
-.kpi-card {
-  background: linear-gradient(135deg, #1e293b 0%, #1a2332 100%);
-  border: 1px solid #334155;
-  border-radius: 0.875rem;
-  padding: 1.75rem;
-  transition: all 200ms ease;
-}
-
-.kpi-card:hover {
-  border-color: #475569;
-  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4);
-  transform: translateY(-3px);
-}
-
-.kpi-icon {
-  width: 2.5rem;
-  height: 2.5rem;
-  border-radius: 0.75rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-}
-
-/* ══════════════════════════════════════════════════════════════
-   DATA CARDS (table wrappers)
-   ══════════════════════════════════════════════════════════════ */
-.data-card {
-  background: linear-gradient(135deg, #1e293b 0%, #1a2332 100%);
-  border: 1px solid #334155;
-  border-radius: 0.875rem;
-  overflow: hidden;
-  transition: all 200ms ease;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
-}
-
-.data-card:hover {
-  border-color: #475569;
-  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4);
-}
-
-/* ══════════════════════════════════════════════════════════════
-   TABLE STYLES
-   ══════════════════════════════════════════════════════════════ */
-table {
-  border-collapse: collapse;
-}
-
-thead {
-  background-color: rgba(30, 41, 59, 0.5);
-  border-bottom: 1px solid #334155;
-}
-
-th {
-  padding: 1rem 1.5rem;
-  font-size: 0.75rem;
-  font-weight: 700;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-  color: #64748b;
-  text-align: left;
-}
-
-td {
-  padding: 1rem 1.5rem;
-  border-bottom: 1px solid #334155;
-  vertical-align: middle;
-  font-size: 0.875rem;
-}
-
-tbody tr {
-  transition: background-color 150ms ease;
-}
-
-tbody tr:hover {
-  background-color: rgba(99, 102, 241, 0.05);
-}
-
-tbody tr:last-child td {
-  border-bottom: none;
-}
-
-/* ══════════════════════════════════════════════════════════════
-   PROJECT LINKS
-   ══════════════════════════════════════════════════════════════ */
-.project-link {
-  color: #a5b4fc;
-  text-decoration: none;
-  font-weight: 500;
-  transition: color 150ms ease;
-}
-
-.project-link:hover {
-  color: #c7d2fe;
-}
-
-/* ══════════════════════════════════════════════════════════════
-   STATUS DOTS & BADGES
-   ══════════════════════════════════════════════════════════════ */
-.status-dot {
-  display: inline-block;
-  width: 0.5rem;
-  height: 0.5rem;
-  border-radius: 50%;
-  flex-shrink: 0;
-}
-
-.status-dot-green { background-color: #10b981; }
-.status-dot-amber { background-color: #f59e0b; }
-.status-dot-red { background-color: #ef4444; }
-.status-dot-indigo { background-color: #6366f1; }
-
-.status-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.25rem 0.75rem;
-  border-radius: 9999px;
-  font-size: 0.75rem;
-  font-weight: 600;
-  white-space: nowrap;
-}
-
-.status-badge-green {
-  color: #6ee7b7;
-  background-color: rgba(16, 185, 129, 0.15);
-}
-
-.status-badge-amber {
-  color: #fcd34d;
-  background-color: rgba(245, 158, 11, 0.15);
-}
-
-.status-badge-red {
-  color: #fca5a5;
-  background-color: rgba(239, 68, 68, 0.15);
-}
-
-.status-badge-indigo {
-  color: #c7d2fe;
-  background-color: rgba(99, 102, 241, 0.15);
-}
-
-/* ══════════════════════════════════════════════════════════════
-   GANTT MINI BARS
-   ══════════════════════════════════════════════════════════════ */
-.gantt-track {
-  width: 100%;
-  min-width: 80px;
-  height: 0.75rem;
-  background: #0f172a;
-  border-radius: 0.25rem;
-  overflow: hidden;
-}
-
-.gantt-fill {
-  height: 100%;
-  border-radius: 0.25rem;
-  background: linear-gradient(90deg, #6366f1 0%, #8b5cf6 100%);
-}
-
-/* ══════════════════════════════════════════════════════════════
-   MOBILE RESPONSIVE
-   ══════════════════════════════════════════════════════════════ */
-
 @media (max-width: 640px) {
-  body {
-    font-size: 0.9375rem;
+
+  h1 {
+    font-size: 1.75rem !important;
+    line-height: 2rem !important;
   }
-  
-  th, td {
-    padding: 0.625rem 0.75rem;
-    font-size: 0.75rem;
+
+  h2 {
+    font-size: 1.125rem !important;
   }
-  
-  th {
-    font-size: 0.65rem;
-    font-weight: 600;
-  }
-  
+
   .kpi-card {
     padding: 1.25rem;
   }
-}
 
-@media (max-width: 768px) {
   th, td {
-    padding: 0.75rem 1rem;
+    padding: 0.75rem;
     font-size: 0.8125rem;
   }
-  
+
   th {
     font-size: 0.7rem;
+    font-weight: 600;
+  }
+
+  .status-badge {
+    padding: 0.25rem 0.5rem;
+    font-size: 0.65rem;
   }
 }
 
+/* ══════════════════════════════════════════════════════════════
+   TABLET RESPONSIVE (641px - 1023px)
+   ══════════════════════════════════════════════════════════════ */
+@media (min-width: 641px) and (max-width: 1023px) {
+  th, td {
+    padding: 0.875rem;
+    font-size: 0.875rem;
+  }
+
+  th {
+    font-size: 0.75rem;
+  }
+}
+
+/* ══════════════════════════════════════════════════════════════
+   DESKTOP RESPONSIVE (≥1024px)
+   ══════════════════════════════════════════════════════════════ */
 @media (min-width: 1024px) {
   .sidebar-panel {
-    height: auto;
+    position: relative !important;
+    inset: auto !important;
+    transform: none !important;
+    top: auto !important;
+    height: 100% !important;
   }
+
+  main {
+    padding: 2rem;
+  }
+}
+
+/* ══════════════════════════════════════════════════════════════
+   UTILITY CLASSES
+   ══════════════════════════════════════════════════════════════ */
+.text-truncate {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.transition-all {
+  transition: all 0.2s ease;
 }

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -251,16 +251,16 @@ body {
    TABLE STYLES
    ══════════════════════════════════════════════════════════════ */
 .table-th {
-  padding: 0.625rem 1rem;
-  font-size: 0.6875rem;
-  font-weight: 600;
-  letter-spacing: 0.06em;
+  padding: 0.75rem 1rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
   color: #64748b; /* slate-500 */
 }
 
 .table-td {
-  padding: 0.75rem 1rem;
+  padding: 1rem;
   vertical-align: middle;
 }
 
@@ -270,7 +270,7 @@ body {
 }
 
 .table-row:hover {
-  background-color: rgb(255 255 255 / 3%);
+  background-color: rgb(255 255 255 / 2.5%);
 }
 
 /* ══════════════════════════════════════════════════════════════

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,18 +1,24 @@
 /* ============================================================
-   Contoso Ltd — Premium Dashboard
-   Supplemental styles (Tailwind handles the rest)
+   Contoso Ltd — Premium Dark SaaS Dashboard
+   Supplemental styles (Tailwind CDN handles utilities)
    ============================================================ */
 
 /* ── Font import ─────────────────────────────────────────────── */
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
 
-/* ── Base font override ──────────────────────────────────────── */
+/* ── Base reset + font override ──────────────────────────────── */
 *, *::before, *::after {
   box-sizing: border-box;
 }
 
+html {
+  scroll-behavior: smooth;
+}
+
 body {
   font-family: Inter, system-ui, -apple-system, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 /* ── Custom scrollbar (webkit) ───────────────────────────────── */
@@ -34,52 +40,398 @@ body {
   background: #6366f1;
 }
 
-/* ── Glass-morphism utility ──────────────────────────────────── */
-.glass {
-  background: rgb(255 255 255 / 5%);
-  backdrop-filter: blur(12px);
-  border: 1px solid rgb(255 255 255 / 8%);
-}
-
 /* ── Animations ──────────────────────────────────────────────── */
 @keyframes fade-in {
   from {
     opacity: 0;
-    transform: translateY(8px);
+    transform: translateY(10px);
   }
-
   to {
     opacity: 1;
     transform: translateY(0);
   }
 }
 
-@keyframes shimmer {
-  0% {
-    background-position: -400px 0;
-  }
-
-  100% {
-    background-position: 400px 0;
-  }
-}
 
 @keyframes status-pulse {
-  0%, 100% { opacity: 1; box-shadow: 0 0 0 0 currentColor; }
-  50%       { opacity: 0.7; box-shadow: 0 0 0 4px transparent; }
+  0%, 100% {
+    opacity: 1;
+    box-shadow: 0 0 0 0 currentColor;
+  }
+  50% {
+    opacity: 0.8;
+    box-shadow: 0 0 0 3px transparent;
+  }
 }
 
 .animate-fade-in {
-  animation: fade-in 0.4s ease-out both;
+  animation: fade-in 0.35s ease-out both;
 }
 
-.shimmer {
-  background: linear-gradient(90deg, #1e293b 25%, #334155 50%, #1e293b 75%);
-  background-size: 400px 100%;
-  animation: shimmer 1.4s infinite linear;
-}
-
-/* Status indicator pulse (for critical/overdue items) */
 .status-pulse {
   animation: status-pulse 1.8s ease-in-out infinite;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   HEADER NAV TABS
+   ══════════════════════════════════════════════════════════════ */
+.nav-tab {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.75rem;
+  border-radius: 0.375rem;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: #94a3b8; /* slate-400 */
+  text-decoration: none;
+  transition: color 150ms ease, background-color 150ms ease;
+  white-space: nowrap;
+}
+
+.nav-tab:hover {
+  color: #fff;
+  background-color: #1e293b; /* slate-800 */
+}
+
+.nav-tab-active {
+  color: #fff;
+  background-color: #312e81; /* indigo-900 */
+  position: relative;
+}
+
+.nav-tab-active::after {
+  content: '';
+  position: absolute;
+  bottom: -1px;
+  left: 0.75rem;
+  right: 0.75rem;
+  height: 2px;
+  background: #6366f1; /* indigo-500 */
+  border-radius: 2px 2px 0 0;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   SIDEBAR
+   ══════════════════════════════════════════════════════════════ */
+.sidebar-section-label {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #475569; /* slate-600 */
+  padding: 0 0.5rem;
+  margin-bottom: 0.25rem;
+}
+
+.sidebar-link {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 0.4rem 0.5rem;
+  border-radius: 0.375rem;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: #94a3b8; /* slate-400 */
+  text-decoration: none;
+  transition: color 150ms ease, background-color 150ms ease;
+}
+
+.sidebar-link:hover {
+  color: #e2e8f0; /* slate-200 */
+  background-color: #1e293b; /* slate-800 */
+}
+
+/* Active sidebar item */
+.sidebar-link-active {
+  color: #c7d2fe; /* indigo-200 */
+  background-color: #312e81; /* indigo-900 */
+}
+
+.sidebar-link-active:hover {
+  color: #e0e7ff; /* indigo-100 */
+  background-color: #3730a3; /* indigo-800 */
+}
+
+.sidebar-icon {
+  width: 1rem;
+  height: 1rem;
+  flex-shrink: 0;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   TOOLBAR BUTTONS
+   ══════════════════════════════════════════════════════════════ */
+.toolbar-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.3125rem 0.75rem;
+  border-radius: 0.375rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: #94a3b8;
+  background-color: #1e293b;
+  border: 1px solid #334155;
+  cursor: pointer;
+  white-space: nowrap;
+  text-decoration: none;
+  transition: color 150ms ease, background-color 150ms ease, border-color 150ms ease, box-shadow 150ms ease;
+}
+
+.toolbar-btn:hover {
+  color: #e2e8f0;
+  background-color: #273449;
+  border-color: #475569;
+  box-shadow: 0 1px 4px rgb(0 0 0 / 30%);
+}
+
+.toolbar-btn-primary {
+  color: #fff;
+  background-color: #4f46e5; /* indigo-600 */
+  border-color: #4f46e5;
+}
+
+.toolbar-btn-primary:hover {
+  color: #fff;
+  background-color: #4338ca; /* indigo-700 */
+  border-color: #4338ca;
+}
+
+.toolbar-btn-danger:hover {
+  color: #fca5a5; /* red-300 */
+  border-color: #ef4444;
+  background-color: #1e293b;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   KPI CARDS
+   ══════════════════════════════════════════════════════════════ */
+.kpi-card {
+  background: #1e293b; /* slate-800 */
+  border: 1px solid #334155; /* slate-700 */
+  border-radius: 0.75rem;
+  padding: 1rem 1.125rem;
+  transition: border-color 200ms ease, box-shadow 200ms ease, transform 200ms ease;
+  cursor: default;
+}
+
+.kpi-card:hover {
+  border-color: #6366f1; /* indigo-500 */
+  box-shadow: 0 4px 24px rgb(99 102 241 / 15%);
+  transform: translateY(-1px);
+}
+
+.kpi-icon {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 0.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   DATA CARDS (table wrappers)
+   ══════════════════════════════════════════════════════════════ */
+.data-card {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 0.75rem;
+  overflow: hidden;
+  transition: border-color 200ms ease, box-shadow 200ms ease;
+}
+
+.data-card:hover {
+  border-color: #475569;
+  box-shadow: 0 2px 16px rgb(0 0 0 / 25%);
+}
+
+/* ══════════════════════════════════════════════════════════════
+   TABLE STYLES
+   ══════════════════════════════════════════════════════════════ */
+.table-th {
+  padding: 0.625rem 1rem;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #64748b; /* slate-500 */
+}
+
+.table-td {
+  padding: 0.75rem 1rem;
+  vertical-align: middle;
+}
+
+/* Subtle row hover */
+.table-row {
+  transition: background-color 150ms ease;
+}
+
+.table-row:hover {
+  background-color: rgb(255 255 255 / 3%);
+}
+
+/* ══════════════════════════════════════════════════════════════
+   PROJECT LINKS
+   ══════════════════════════════════════════════════════════════ */
+.project-link {
+  color: #a5b4fc; /* indigo-300 */
+  text-decoration: none;
+  font-weight: 500;
+  transition: color 150ms ease;
+}
+
+.project-link:hover {
+  color: #c7d2fe; /* indigo-200 */
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   STATUS DOTS
+   ══════════════════════════════════════════════════════════════ */
+.status-dot {
+  display: inline-block;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 9999px;
+  flex-shrink: 0;
+}
+
+.status-dot-green  { background-color: #10b981; } /* emerald-500 */
+.status-dot-amber  { background-color: #f59e0b; } /* amber-500 */
+.status-dot-red    { background-color: #ef4444; } /* red-500 */
+.status-dot-indigo { background-color: #6366f1; } /* indigo-500 */
+
+/* ══════════════════════════════════════════════════════════════
+   STATUS BADGES
+   ══════════════════════════════════════════════════════════════ */
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.1875rem 0.5rem;
+  border-radius: 9999px;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+
+/* Prepend a colored dot using ::before */
+.status-badge::before {
+  content: '';
+  display: inline-block;
+  width: 0.4375rem;
+  height: 0.4375rem;
+  border-radius: 9999px;
+  flex-shrink: 0;
+}
+
+.status-badge-green {
+  color: #6ee7b7; /* emerald-300 */
+  background-color: rgb(16 185 129 / 15%);
+}
+.status-badge-green::before { background-color: #10b981; }
+
+.status-badge-amber {
+  color: #fcd34d; /* amber-300 */
+  background-color: rgb(245 158 11 / 15%);
+}
+.status-badge-amber::before { background-color: #f59e0b; }
+
+.status-badge-red {
+  color: #fca5a5; /* red-300 */
+  background-color: rgb(239 68 68 / 15%);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+.status-badge-red::before { background-color: #ef4444; }
+
+.status-badge-indigo {
+  color: #c7d2fe; /* indigo-200 */
+  background-color: rgb(99 102 241 / 15%);
+}
+.status-badge-indigo::before { background-color: #6366f1; }
+
+/* ══════════════════════════════════════════════════════════════
+   UTILISATION BADGES
+   ══════════════════════════════════════════════════════════════ */
+.util-badge {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.25rem;
+  white-space: nowrap;
+}
+
+.util-badge-med  { color: #6ee7b7; background-color: rgb(16 185 129 / 15%); }  /* ≤80% */
+.util-badge-high { color: #fcd34d; background-color: rgb(245 158 11 / 15%); }  /* 81-95% */
+.util-badge-over { color: #fca5a5; background-color: rgb(239 68 68 / 15%); }   /* >95% */
+
+/* ══════════════════════════════════════════════════════════════
+   GANTT MINI BARS
+   ══════════════════════════════════════════════════════════════ */
+.gantt-track {
+  width: 100%;
+  min-width: 80px;
+  height: 1rem;
+  background: #0f172a;
+  border-radius: 0.25rem;
+  overflow: hidden;
+  position: relative;
+}
+
+.gantt-fill {
+  height: 100%;
+  border-radius: 0.25rem;
+  min-width: 4px;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   GLASS UTILITY
+   ══════════════════════════════════════════════════════════════ */
+.glass {
+  background: rgb(255 255 255 / 5%);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid rgb(255 255 255 / 8%);
+}
+
+/* ══════════════════════════════════════════════════════════════
+   MOBILE RESPONSIVE OVERRIDES
+   ══════════════════════════════════════════════════════════════ */
+
+/* Sidebar panel base — always fixed on mobile */
+.sidebar-panel {
+  height: calc(100vh - 3.5rem); /* below 14-unit header */
+}
+
+/* On large screens the sidebar is part of the normal flow */
+@media (min-width: 1024px) {
+  .sidebar-panel {
+    height: auto;
+    position: relative;
+    top: auto;
+    left: auto;
+    transform: none !important;
+  }
+}
+
+/* Prevent layout jitter from scrollbar appearing/disappearing */
+@media (max-width: 1023px) {
+  body.overflow-hidden {
+    overflow: hidden;
+  }
+}
+
+/* Tighter padding on small screens */
+@media (max-width: 639px) {
+  .table-th,
+  .table-td {
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
+  }
 }

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -23,8 +23,8 @@ body {
 
 /* ── Custom scrollbar (webkit) ───────────────────────────────── */
 ::-webkit-scrollbar {
-  width: 6px;
-  height: 6px;
+  width: 7px;
+  height: 7px;
 }
 
 ::-webkit-scrollbar-track {
@@ -52,179 +52,73 @@ body {
   }
 }
 
-
-@keyframes status-pulse {
-  0%, 100% {
-    opacity: 1;
-    box-shadow: 0 0 0 0 currentColor;
-  }
-  50% {
-    opacity: 0.8;
-    box-shadow: 0 0 0 3px transparent;
-  }
-}
-
 .animate-fade-in {
   animation: fade-in 0.35s ease-out both;
-}
-
-.status-pulse {
-  animation: status-pulse 1.8s ease-in-out infinite;
-}
-
-/* ══════════════════════════════════════════════════════════════
-   HEADER NAV TABS
-   ══════════════════════════════════════════════════════════════ */
-.nav-tab {
-  display: inline-flex;
-  align-items: center;
-  padding: 0.25rem 0.75rem;
-  border-radius: 0.375rem;
-  font-size: 0.8125rem;
-  font-weight: 500;
-  color: #94a3b8; /* slate-400 */
-  text-decoration: none;
-  transition: color 150ms ease, background-color 150ms ease;
-  white-space: nowrap;
-}
-
-.nav-tab:hover {
-  color: #fff;
-  background-color: #1e293b; /* slate-800 */
-}
-
-.nav-tab-active {
-  color: #fff;
-  background-color: #312e81; /* indigo-900 */
-  position: relative;
-}
-
-.nav-tab-active::after {
-  content: '';
-  position: absolute;
-  bottom: -1px;
-  left: 0.75rem;
-  right: 0.75rem;
-  height: 2px;
-  background: #6366f1; /* indigo-500 */
-  border-radius: 2px 2px 0 0;
 }
 
 /* ══════════════════════════════════════════════════════════════
    SIDEBAR
    ══════════════════════════════════════════════════════════════ */
-.sidebar-section-label {
-  font-size: 0.6875rem;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: #475569; /* slate-600 */
-  padding: 0 0.5rem;
-  margin-bottom: 0.25rem;
-}
-
 .sidebar-link {
   display: flex;
   align-items: center;
-  gap: 0.625rem;
-  padding: 0.4rem 0.5rem;
-  border-radius: 0.375rem;
-  font-size: 0.8125rem;
+  gap: 0.75rem;
+  padding: 0.625rem 0.75rem;
+  border-radius: 0.5rem;
+  font-size: 0.875rem;
   font-weight: 500;
-  color: #94a3b8; /* slate-400 */
+  color: #94a3b8;
   text-decoration: none;
   transition: color 150ms ease, background-color 150ms ease;
 }
 
 .sidebar-link:hover {
-  color: #e2e8f0; /* slate-200 */
-  background-color: #1e293b; /* slate-800 */
+  color: #e2e8f0;
+  background-color: #1e293b;
 }
 
-/* Active sidebar item */
 .sidebar-link-active {
-  color: #c7d2fe; /* indigo-200 */
-  background-color: #312e81; /* indigo-900 */
+  color: #c7d2fe;
+  background-color: #312e81;
 }
 
 .sidebar-link-active:hover {
-  color: #e0e7ff; /* indigo-100 */
-  background-color: #3730a3; /* indigo-800 */
+  color: #e0e7ff;
+  background-color: #3730a3;
+}
+
+.sidebar-link span {
+  flex: 1;
 }
 
 .sidebar-icon {
-  width: 1rem;
-  height: 1rem;
+  width: 1.25rem;
+  height: 1.25rem;
   flex-shrink: 0;
-}
-
-/* ══════════════════════════════════════════════════════════════
-   TOOLBAR BUTTONS
-   ══════════════════════════════════════════════════════════════ */
-.toolbar-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.375rem;
-  padding: 0.3125rem 0.75rem;
-  border-radius: 0.375rem;
-  font-size: 0.75rem;
-  font-weight: 500;
-  color: #94a3b8;
-  background-color: #1e293b;
-  border: 1px solid #334155;
-  cursor: pointer;
-  white-space: nowrap;
-  text-decoration: none;
-  transition: color 150ms ease, background-color 150ms ease, border-color 150ms ease, box-shadow 150ms ease;
-}
-
-.toolbar-btn:hover {
-  color: #e2e8f0;
-  background-color: #273449;
-  border-color: #475569;
-  box-shadow: 0 1px 4px rgb(0 0 0 / 30%);
-}
-
-.toolbar-btn-primary {
-  color: #fff;
-  background-color: #4f46e5; /* indigo-600 */
-  border-color: #4f46e5;
-}
-
-.toolbar-btn-primary:hover {
-  color: #fff;
-  background-color: #4338ca; /* indigo-700 */
-  border-color: #4338ca;
-}
-
-.toolbar-btn-danger:hover {
-  color: #fca5a5; /* red-300 */
-  border-color: #ef4444;
-  background-color: #1e293b;
+  stroke-width: 1.75;
 }
 
 /* ══════════════════════════════════════════════════════════════
    KPI CARDS
    ══════════════════════════════════════════════════════════════ */
 .kpi-card {
-  background: #1e293b; /* slate-800 */
-  border: 1px solid #334155; /* slate-700 */
-  border-radius: 0.75rem;
-  padding: 1rem 1.125rem;
-  transition: border-color 200ms ease, box-shadow 200ms ease, transform 200ms ease;
-  cursor: default;
+  background: linear-gradient(135deg, #1e293b 0%, #1a2332 100%);
+  border: 1px solid #334155;
+  border-radius: 0.875rem;
+  padding: 1.75rem;
+  transition: all 200ms ease;
 }
 
 .kpi-card:hover {
-  border-color: #6366f1; /* indigo-500 */
-  box-shadow: 0 4px 24px rgb(99 102 241 / 15%);
-  transform: translateY(-1px);
+  border-color: #475569;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4);
+  transform: translateY(-3px);
 }
 
 .kpi-icon {
-  width: 2rem;
-  height: 2rem;
-  border-radius: 0.5rem;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 0.75rem;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -235,141 +129,120 @@ body {
    DATA CARDS (table wrappers)
    ══════════════════════════════════════════════════════════════ */
 .data-card {
-  background: #1e293b;
+  background: linear-gradient(135deg, #1e293b 0%, #1a2332 100%);
   border: 1px solid #334155;
-  border-radius: 0.75rem;
+  border-radius: 0.875rem;
   overflow: hidden;
-  transition: border-color 200ms ease, box-shadow 200ms ease;
+  transition: all 200ms ease;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
 }
 
 .data-card:hover {
   border-color: #475569;
-  box-shadow: 0 2px 16px rgb(0 0 0 / 25%);
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4);
 }
 
 /* ══════════════════════════════════════════════════════════════
    TABLE STYLES
    ══════════════════════════════════════════════════════════════ */
-.table-th {
-  padding: 0.75rem 1rem;
+table {
+  border-collapse: collapse;
+}
+
+thead {
+  background-color: rgba(30, 41, 59, 0.5);
+  border-bottom: 1px solid #334155;
+}
+
+th {
+  padding: 1rem 1.5rem;
   font-size: 0.75rem;
   font-weight: 700;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.05em;
   text-transform: uppercase;
-  color: #64748b; /* slate-500 */
+  color: #64748b;
+  text-align: left;
 }
 
-.table-td {
-  padding: 1rem;
+td {
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid #334155;
   vertical-align: middle;
+  font-size: 0.875rem;
 }
 
-/* Subtle row hover */
-.table-row {
+tbody tr {
   transition: background-color 150ms ease;
 }
 
-.table-row:hover {
-  background-color: rgb(255 255 255 / 2.5%);
+tbody tr:hover {
+  background-color: rgba(99, 102, 241, 0.05);
+}
+
+tbody tr:last-child td {
+  border-bottom: none;
 }
 
 /* ══════════════════════════════════════════════════════════════
    PROJECT LINKS
    ══════════════════════════════════════════════════════════════ */
 .project-link {
-  color: #a5b4fc; /* indigo-300 */
+  color: #a5b4fc;
   text-decoration: none;
   font-weight: 500;
   transition: color 150ms ease;
 }
 
 .project-link:hover {
-  color: #c7d2fe; /* indigo-200 */
-  text-decoration: underline;
-  text-underline-offset: 2px;
+  color: #c7d2fe;
 }
 
 /* ══════════════════════════════════════════════════════════════
-   STATUS DOTS
+   STATUS DOTS & BADGES
    ══════════════════════════════════════════════════════════════ */
 .status-dot {
   display: inline-block;
   width: 0.5rem;
   height: 0.5rem;
-  border-radius: 9999px;
+  border-radius: 50%;
   flex-shrink: 0;
 }
 
-.status-dot-green  { background-color: #10b981; } /* emerald-500 */
-.status-dot-amber  { background-color: #f59e0b; } /* amber-500 */
-.status-dot-red    { background-color: #ef4444; } /* red-500 */
-.status-dot-indigo { background-color: #6366f1; } /* indigo-500 */
+.status-dot-green { background-color: #10b981; }
+.status-dot-amber { background-color: #f59e0b; }
+.status-dot-red { background-color: #ef4444; }
+.status-dot-indigo { background-color: #6366f1; }
 
-/* ══════════════════════════════════════════════════════════════
-   STATUS BADGES
-   ══════════════════════════════════════════════════════════════ */
 .status-badge {
   display: inline-flex;
   align-items: center;
-  gap: 0.375rem;
-  padding: 0.1875rem 0.5rem;
+  gap: 0.5rem;
+  padding: 0.25rem 0.75rem;
   border-radius: 9999px;
-  font-size: 0.6875rem;
+  font-size: 0.75rem;
   font-weight: 600;
-  letter-spacing: 0.02em;
   white-space: nowrap;
-}
-
-/* Prepend a colored dot using ::before */
-.status-badge::before {
-  content: '';
-  display: inline-block;
-  width: 0.4375rem;
-  height: 0.4375rem;
-  border-radius: 9999px;
-  flex-shrink: 0;
 }
 
 .status-badge-green {
-  color: #6ee7b7; /* emerald-300 */
-  background-color: rgb(16 185 129 / 15%);
+  color: #6ee7b7;
+  background-color: rgba(16, 185, 129, 0.15);
 }
-.status-badge-green::before { background-color: #10b981; }
 
 .status-badge-amber {
-  color: #fcd34d; /* amber-300 */
-  background-color: rgb(245 158 11 / 15%);
+  color: #fcd34d;
+  background-color: rgba(245, 158, 11, 0.15);
 }
-.status-badge-amber::before { background-color: #f59e0b; }
 
 .status-badge-red {
-  color: #fca5a5; /* red-300 */
-  background-color: rgb(239 68 68 / 15%);
-  font-weight: 700;
-  letter-spacing: 0.04em;
+  color: #fca5a5;
+  background-color: rgba(239, 68, 68, 0.15);
 }
-.status-badge-red::before { background-color: #ef4444; }
 
 .status-badge-indigo {
-  color: #c7d2fe; /* indigo-200 */
-  background-color: rgb(99 102 241 / 15%);
+  color: #c7d2fe;
+  background-color: rgba(99, 102, 241, 0.15);
 }
-.status-badge-indigo::before { background-color: #6366f1; }
-
-/* ══════════════════════════════════════════════════════════════
-   UTILISATION BADGES
-   ══════════════════════════════════════════════════════════════ */
-.util-badge {
-  font-size: 0.6875rem;
-  font-weight: 600;
-  padding: 0.125rem 0.375rem;
-  border-radius: 0.25rem;
-  white-space: nowrap;
-}
-
-.util-badge-med  { color: #6ee7b7; background-color: rgb(16 185 129 / 15%); }  /* ≤80% */
-.util-badge-high { color: #fcd34d; background-color: rgb(245 158 11 / 15%); }  /* 81-95% */
-.util-badge-over { color: #fca5a5; background-color: rgb(239 68 68 / 15%); }   /* >95% */
 
 /* ══════════════════════════════════════════════════════════════
    GANTT MINI BARS
@@ -377,61 +250,55 @@ body {
 .gantt-track {
   width: 100%;
   min-width: 80px;
-  height: 1rem;
+  height: 0.75rem;
   background: #0f172a;
   border-radius: 0.25rem;
   overflow: hidden;
-  position: relative;
 }
 
 .gantt-fill {
   height: 100%;
   border-radius: 0.25rem;
-  min-width: 4px;
+  background: linear-gradient(90deg, #6366f1 0%, #8b5cf6 100%);
 }
 
 /* ══════════════════════════════════════════════════════════════
-   GLASS UTILITY
-   ══════════════════════════════════════════════════════════════ */
-.glass {
-  background: rgb(255 255 255 / 5%);
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
-  border: 1px solid rgb(255 255 255 / 8%);
-}
-
-/* ══════════════════════════════════════════════════════════════
-   MOBILE RESPONSIVE OVERRIDES
+   MOBILE RESPONSIVE
    ══════════════════════════════════════════════════════════════ */
 
-/* Sidebar panel base — always fixed on mobile */
-.sidebar-panel {
-  height: calc(100vh - 3.5rem); /* below 14-unit header */
+@media (max-width: 640px) {
+  body {
+    font-size: 0.9375rem;
+  }
+  
+  th, td {
+    padding: 0.625rem 0.75rem;
+    font-size: 0.75rem;
+  }
+  
+  th {
+    font-size: 0.65rem;
+    font-weight: 600;
+  }
+  
+  .kpi-card {
+    padding: 1.25rem;
+  }
 }
 
-/* On large screens the sidebar is part of the normal flow */
+@media (max-width: 768px) {
+  th, td {
+    padding: 0.75rem 1rem;
+    font-size: 0.8125rem;
+  }
+  
+  th {
+    font-size: 0.7rem;
+  }
+}
+
 @media (min-width: 1024px) {
   .sidebar-panel {
     height: auto;
-    position: relative;
-    top: auto;
-    left: auto;
-    transform: none !important;
-  }
-}
-
-/* Prevent layout jitter from scrollbar appearing/disappearing */
-@media (max-width: 1023px) {
-  body.overflow-hidden {
-    overflow: hidden;
-  }
-}
-
-/* Tighter padding on small screens */
-@media (max-width: 639px) {
-  .table-th,
-  .table-td {
-    padding-left: 0.75rem;
-    padding-right: 0.75rem;
   }
 }

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,393 +1,85 @@
 /* ============================================================
-   Contoso Project Server 2005 — Retro Stylesheet
-   Pixel-perfect recreation of mid-2000s enterprise UI
+   Contoso Ltd — Premium Dashboard
+   Supplemental styles (Tailwind handles the rest)
    ============================================================ */
 
-* {
-  margin: 0;
-  padding: 0;
+/* ── Font import ─────────────────────────────────────────────── */
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
+
+/* ── Base font override ──────────────────────────────────────── */
+*, *::before, *::after {
   box-sizing: border-box;
 }
 
 body {
-  font-family: Verdana, Tahoma, Arial, sans-serif;
-  font-size: 11px;
-  color: #333;
-  background: #e8e8d8;
+  font-family: Inter, system-ui, -apple-system, sans-serif;
 }
 
-a {
-  color: #003399;
-  text-decoration: none;
-}
-a:hover {
-  text-decoration: underline;
+/* ── Custom scrollbar (webkit) ───────────────────────────────── */
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
 }
 
-/* ── Top bar ─────────────────────────────────────────────────── */
-.topbar {
-  background: linear-gradient(to bottom, #003a7a, #002255);
-  color: #fff;
-  padding: 6px 10px;
-  border-bottom: 2px solid #f0c040;
-}
-.topbar-left {
-  vertical-align: middle;
-}
-.logo-img {
-  width: 24px;
-  height: 24px;
-  vertical-align: middle;
-  margin-right: 6px;
-  /* Placeholder — we'll use a CSS fallback */
-  background: #f0c040;
-  border: 1px solid #c8a020;
-  display: inline-block;
-}
-.topbar-title {
-  font-size: 14px;
-  font-weight: bold;
-  font-family: "Trebuchet MS", Verdana, sans-serif;
-  letter-spacing: 0.5px;
-}
-.topbar-right {
-  text-align: right;
-  font-size: 10px;
-  vertical-align: middle;
-}
-.topbar-right a {
-  color: #b0d0ff;
+::-webkit-scrollbar-track {
+  background: #0f172a;
 }
 
-/* ── Navigation bar ──────────────────────────────────────────── */
-.navbar {
-  background: linear-gradient(to bottom, #3a7abf, #1a5a9f);
-  border-bottom: 1px solid #003060;
-  padding: 0 8px;
-}
-.nav-item {
-  padding: 6px 14px;
-  color: #d0e4ff;
-  font-size: 11px;
-  font-weight: bold;
-  cursor: pointer;
-  border-right: 1px solid #2868a8;
-}
-.nav-item:hover {
-  background: rgba(255,255,255,0.15);
-}
-.nav-active {
-  background: #f5f5ec;
-  color: #003060;
-  border-bottom: 2px solid #f5f5ec;
+::-webkit-scrollbar-thumb {
+  background: #334155;
+  border-radius: 3px;
 }
 
-/* ── Toolbar ─────────────────────────────────────────────────── */
-.toolbar {
-  background: #f5f5ec;
-  border-bottom: 1px solid #c0c0a8;
-  padding: 3px 10px;
-}
-.toolbar-btn {
-  padding: 2px 6px;
-  font-size: 10px;
-  color: #003399;
-  cursor: pointer;
-}
-.toolbar-btn:hover {
-  color: #0055cc;
-}
-.toolbar-sep {
-  color: #c0c0a8;
-  padding: 2px 4px;
+::-webkit-scrollbar-thumb:hover {
+  background: #6366f1;
 }
 
-/* ── Main layout ─────────────────────────────────────────────── */
-.main-layout {
-  width: 100%;
+/* ── Glass-morphism utility ──────────────────────────────────── */
+.glass {
+  background: rgb(255 255 255 / 5%);
+  backdrop-filter: blur(12px);
+  border: 1px solid rgb(255 255 255 / 8%);
 }
 
-/* ── Sidebar ─────────────────────────────────────────────────── */
-.sidebar {
-  width: 180px;
-  background: #f0f0e0;
-  border-right: 1px solid #c8c8b0;
-  vertical-align: top;
-  padding: 0;
-}
-.sidebar-header {
-  background: linear-gradient(to bottom, #e8e0c0, #d8d0b0);
-  padding: 6px 10px;
-  font-weight: bold;
-  font-size: 11px;
-  color: #333;
-  border-bottom: 1px solid #c0b890;
-}
-.sidebar-section {
-  padding: 4px 0;
-  border-bottom: 1px solid #d8d0b8;
-}
-.sidebar-section-title {
-  font-weight: bold;
-  font-size: 10px;
-  color: #666;
-  text-transform: uppercase;
-  padding: 4px 10px 2px;
-}
-.sidebar-link {
-  display: block;
-  padding: 2px 10px 2px 14px;
-  font-size: 11px;
-  color: #003399;
-}
-.sidebar-link:hover {
-  background: #e0e0cc;
-}
-.sidebar-hr {
-  border: none;
-  border-top: 1px solid #c8c8b0;
-  margin: 6px 10px;
-}
-.sidebar-footer {
-  padding: 4px 10px;
-  font-size: 10px;
-}
-.icon-tiny {
-  width: 12px;
-  height: 12px;
-  vertical-align: middle;
-  display: inline-block;
-  background: #a0a090;
-}
-.icon-small {
-  width: 16px;
-  height: 16px;
-  vertical-align: middle;
-  display: inline-block;
-  background: #c0b878;
-  margin-right: 4px;
+/* ── Animations ──────────────────────────────────────────────── */
+@keyframes fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
-/* ── Content area ────────────────────────────────────────────── */
-.content {
-  vertical-align: top;
-  padding: 10px 14px;
-  background: #fff;
-}
-.page-title {
-  font-size: 16px;
-  font-family: "Trebuchet MS", Verdana, sans-serif;
-  color: #003060;
-  margin-bottom: 2px;
-  font-weight: normal;
-}
-.breadcrumb {
-  font-size: 10px;
-  color: #888;
-  margin-bottom: 10px;
+@keyframes shimmer {
+  0% {
+    background-position: -400px 0;
+  }
+
+  100% {
+    background-position: 400px 0;
+  }
 }
 
-/* ── Summary boxes ───────────────────────────────────────────── */
-.summary-boxes {
-  margin-bottom: 12px;
-  width: 100%;
-}
-.summary-box {
-  background: #f8f8f0;
-  border: 1px solid #d0d0c0;
-  text-align: center;
-  padding: 8px 16px;
-  width: 20%;
-}
-.summary-label {
-  font-size: 10px;
-  color: #666;
-  text-transform: uppercase;
-  margin-bottom: 2px;
-}
-.summary-value {
-  font-size: 22px;
-  font-weight: bold;
-  color: #333;
-  font-family: "Trebuchet MS", Verdana, sans-serif;
-}
-.summary-green { color: #228b22; }
-.summary-amber { color: #cc8800; }
-.summary-red { color: #cc0000; }
-
-/* ── Data table ──────────────────────────────────────────────── */
-.data-table {
-  width: 100%;
-  border-collapse: collapse;
-  border: 1px solid #c0c0a8;
-  margin-bottom: 6px;
-}
-.data-table th {
-  background: linear-gradient(to bottom, #e8e0c0, #d8d0a8);
-  border: 1px solid #c0b890;
-  padding: 4px 6px;
-  font-size: 10px;
-  font-weight: bold;
-  color: #333;
-  text-align: left;
-  white-space: nowrap;
-}
-.data-table th a {
-  color: #003060;
-}
-.data-table td {
-  border: 1px solid #ddd;
-  padding: 3px 6px;
-  font-size: 11px;
-  vertical-align: middle;
-}
-.row-even { background: #fff; }
-.row-odd { background: #f4f4ec; }
-.row-even:hover, .row-odd:hover { background: #e8e8d0; }
-
-.col-check { width: 20px; text-align: center; }
-.col-indicator { width: 14px; text-align: center; }
-.col-budget { text-align: right; font-family: "Courier New", monospace; }
-
-.indicator {
-  display: inline-block;
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  border: 1px solid #888;
-}
-.indicator.green { background: #44aa44; }
-.indicator.amber { background: #ddaa00; }
-.indicator.red { background: #cc3333; }
-
-.project-link {
-  font-weight: bold;
+@keyframes status-pulse {
+  0%, 100% { opacity: 1; box-shadow: 0 0 0 0 currentColor; }
+  50%       { opacity: 0.7; box-shadow: 0 0 0 4px transparent; }
 }
 
-/* ── Progress bars ───────────────────────────────────────────── */
-.progress-bar {
-  width: 80px;
-  display: inline-table;
-  height: 12px;
-  border: 1px solid #999;
-  vertical-align: middle;
-}
-.progress-fill {
-  background: linear-gradient(to bottom, #6699cc, #336699);
-  height: 10px;
-}
-.progress-fill.progress-amber {
-  background: linear-gradient(to bottom, #ddaa44, #bb8822);
-}
-.progress-fill.progress-red {
-  background: linear-gradient(to bottom, #cc6644, #aa3322);
-}
-.progress-empty {
-  background: #e8e8e0;
-}
-.progress-text {
-  font-size: 10px;
-  margin-left: 4px;
-  color: #555;
+.animate-fade-in {
+  animation: fade-in 0.4s ease-out both;
 }
 
-/* ── Status labels ───────────────────────────────────────────── */
-.status-on-track {
-  background: #d4edda;
-  color: #155724;
-  padding: 1px 6px;
-  border: 1px solid #b8dcc0;
-  font-size: 10px;
-  font-weight: bold;
-}
-.status-at-risk {
-  background: #fff3cd;
-  color: #856404;
-  padding: 1px 6px;
-  border: 1px solid #eed888;
-  font-size: 10px;
-  font-weight: bold;
-}
-.status-critical {
-  background: #f8d7da;
-  color: #721c24;
-  padding: 1px 6px;
-  border: 1px solid #f0b0b8;
-  font-size: 10px;
-  font-weight: bold;
-  animation: blink 1.5s step-end infinite;
-}
-@keyframes blink {
-  50% { opacity: 0.4; }
+.shimmer {
+  background: linear-gradient(90deg, #1e293b 25%, #334155 50%, #1e293b 75%);
+  background-size: 400px 100%;
+  animation: shimmer 1.4s infinite linear;
 }
 
-/* ── Gantt mini-bars ─────────────────────────────────────────── */
-.col-gantt {
-  width: 120px;
-  position: relative;
-  background: repeating-linear-gradient(
-    to right,
-    #f0f0e8 0px, #f0f0e8 29px,
-    #ddd 29px, #ddd 30px
-  );
-}
-.gantt-bar {
-  height: 10px;
-  border-radius: 1px;
-  position: relative;
-  top: 0;
-}
-.gantt-green { background: linear-gradient(to bottom, #66aa66, #448844); }
-.gantt-blue { background: linear-gradient(to bottom, #6688cc, #445588); }
-.gantt-amber { background: linear-gradient(to bottom, #ddaa44, #bb8822); }
-.gantt-red { background: linear-gradient(to bottom, #cc5544, #993322); }
-
-/* ── Table footer & paging ───────────────────────────────────── */
-.table-footer {
-  font-size: 10px;
-  color: #666;
-  padding: 4px 0;
-  display: flex;
-  justify-content: space-between;
-  margin-bottom: 16px;
-}
-.paging a, .paging {
-  color: #888;
-}
-
-/* ── Section titles ──────────────────────────────────────────── */
-.section-title {
-  font-size: 13px;
-  font-family: "Trebuchet MS", Verdana, sans-serif;
-  color: #003060;
-  font-weight: normal;
-  margin-bottom: 6px;
-  padding-bottom: 2px;
-  border-bottom: 1px solid #c0c0a8;
-}
-
-/* ── Utilization labels ──────────────────────────────────────── */
-.util-med { color: #228b22; font-weight: bold; }
-.util-high { color: #cc8800; font-weight: bold; }
-.util-over { color: #cc0000; font-weight: bold; }
-
-/* ── Resource table ──────────────────────────────────────────── */
-.resource-table {
-  max-width: 700px;
-}
-
-/* ── Page footer ─────────────────────────────────────────────── */
-.page-footer {
-  margin-top: 20px;
-  font-size: 9px;
-  color: #999;
-}
-.page-footer hr {
-  border: none;
-  border-top: 1px solid #d0d0c0;
-  margin-bottom: 4px;
-}
-.page-footer a {
-  color: #888;
-  font-size: 9px;
+/* Status indicator pulse (for critical/overdue items) */
+.status-pulse {
+  animation: status-pulse 1.8s ease-in-out infinite;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,288 @@
       "version": "1.0.0",
       "dependencies": {
         "serve": "^14.2.4"
+      },
+      "devDependencies": {
+        "stylelint": "^17.4.0",
+        "stylelint-config-standard": "^40.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cacheable/memory": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.8.tgz",
+      "integrity": "sha512-FvEb29x5wVwu/Kf93IWwsOOEuhHh6dYCJF3vcKLzXc0KXIW181AOzv6ceT4ZpBHDvAfG60eqb+ekmrnLHIy+jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/utils": "^2.4.0",
+        "@keyv/bigmap": "^1.3.1",
+        "hookified": "^1.15.1",
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@cacheable/utils": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.4.0.tgz",
+      "integrity": "sha512-PeMMsqjVq+bF0WBsxFBxr/WozBJiZKY0rUojuaCoIaKnEl3Ju1wfEwS+SV1DU/cSe8fqHIPiYJFif8T3MVt4cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.5.0",
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.0.tgz",
+      "integrity": "sha512-H4tuz2nhWgNKLt1inYpoVCfbJbMwX/lQKp3g69rrrIMIYlFD9+zTykOKhNR8uGrAmbS/kT9n6hTFkmDkxLgeTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0"
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/media-query-list-parser": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-5.0.0.tgz",
+      "integrity": "sha512-T9lXmZOfnam3eMERPsszjY5NK0jX8RmThmmm99FZ8b7z8yMaFZWKwLWGZuTwdO3ddRY5fy13GmmEYZXB4I98Eg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/selector-resolve-nested": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-4.0.0.tgz",
+      "integrity": "sha512-9vAPxmp+Dx3wQBIUwc1v7Mdisw1kbbaGqXUM8QLTgWg7SoPGYtXBsMXvsFs/0Bn5yoFhcktzxNZGNaUt0VjgjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^7.1.1"
+      }
+    },
+    "node_modules/@csstools/selector-specificity": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-6.0.0.tgz",
+      "integrity": "sha512-4sSgl78OtOXEX/2d++8A83zHNTgwCJMaR24FvsYL7Uf/VS8HZk9PTwR51elTbGqMuwH3szLvvOXEaVnqn0Z3zA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^7.1.1"
+      }
+    },
+    "node_modules/@keyv/bigmap": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
+      "integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.4.0",
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@keyv/serialize": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
+      "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@zeit/schemas": {
@@ -133,6 +415,23 @@
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
       "license": "MIT"
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -171,6 +470,19 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -178,6 +490,30 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/cacheable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.3.tgz",
+      "integrity": "sha512-iffYMX4zxKp54evOH27fm92hs+DeC1DhXmNVN8Tr94M/iZIV42dqTHSR2Ik4TOSPyOAwKr7Yu3rN9ALoLkbWyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/memory": "^2.0.8",
+        "@cacheable/utils": "^2.4.0",
+        "hookified": "^1.15.0",
+        "keyv": "^5.6.0",
+        "qified": "^0.6.0"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/camelcase": {
@@ -297,6 +633,13 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/colord": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
+      "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/compressible": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
@@ -342,6 +685,33 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/cosmiconfig": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
+      "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -354,6 +724,43 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-functions-list": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.3.3.tgz",
+      "integrity": "sha512-8HFEBPKhOpJPEPu70wJJetjKta86Gw9+CCyCnB3sui2qQfOvRyqBy4IKLKKAwdMpWb2lHXWk9Wb4Z6AmaUT1Pg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/debug": {
@@ -386,6 +793,26 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "license": "MIT"
     },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -415,6 +842,23 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -431,6 +875,81 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fastest-levenshtein": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.9.1"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.2.tgz",
+      "integrity": "sha512-N2WFfK12gmrK1c1GXOqiAJ1tc5YE+R53zvQ+t5P8S5XhnmKYVB5eZEiLNZKDSmoG8wqqbF9EXYBBW/nef19log==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^6.1.20"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "6.1.20",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.20.tgz",
+      "integrity": "sha512-AhHYqwvN62NVLp4lObVXGVluiABTHapoB57EyegZVmazN+hhGhLTn3uZbOofoTw4DSDvVCadzzyChXhOAvy8uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cacheable": "^2.3.2",
+        "flatted": "^3.3.3",
+        "hookified": "^1.15.0"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
+      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-stream": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
@@ -443,6 +962,88 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/global-modules": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+      "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "global-prefix": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/global-prefix": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+      "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.5",
+        "kind-of": "^6.0.2",
+        "which": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/global-prefix/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/globby": {
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-16.1.1.tgz",
+      "integrity": "sha512-dW7vl+yiAJSp6aCekaVnVJxurRv7DCOLyXqEG3RYMYUg7AuJ2jCqPkZTA8ooqC2vtnkaMcV5WfFBMuEnTu1OQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "fast-glob": "^3.3.3",
+        "ignore": "^7.0.5",
+        "is-path-inside": "^4.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globjoin": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
+      "integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -450,6 +1051,39 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/hashery": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.0.tgz",
+      "integrity": "sha512-nhQ6ExaOIqti2FDWoEMWARUqIKyjr2VcZzXShrI+A3zpeiuPWzx6iPftt44LhP74E5sW36B75N6VHbvRtpvO6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^1.14.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/hookified": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
+      "integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/html-tags": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-5.1.0.tgz",
+      "integrity": "sha512-n6l5uca7/y5joxZ3LUePhzmBFUJ+U2YWzhMa8XUTecSeSlQiZdF5XAd/Q3/WUl0VsXgUwWi8I7CNIwdI5WN1SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/human-signals": {
@@ -461,11 +1095,66 @@
         "node": ">=10.17.0"
       }
     },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
     "node_modules/ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-docker": {
       "version": "2.2.1",
@@ -482,6 +1171,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -489,6 +1188,52 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-port-reachable": {
@@ -533,17 +1278,133 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
+    "node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mathml-tag-names": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-4.0.0.tgz",
+      "integrity": "sha512-aa6AU2Pcx0VP/XWnh8IGL0SYSgQHDT6Ucror2j2mXeFAlN3ahaNs8EZtG1YiticMkSLj3Gt6VPFfZogt7G5iFQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/meow": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-14.1.0.tgz",
+      "integrity": "sha512-EDYo6VlmtnumlcBCbh1gLJ//9jvM/ndXHfVXIFrZVr6fGcwTUyCTFNTLCKuY3ffbK8L/+3Mzqnd58RojiZqHVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "license": "MIT"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
     },
     "node_modules/mime-db": {
       "version": "1.54.0",
@@ -611,6 +1472,25 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/negotiator": {
       "version": "0.6.4",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
@@ -618,6 +1498,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/npm-run-path": {
@@ -656,6 +1546,38 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/path-is-inside": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
@@ -675,6 +1597,137 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.3.0.tgz",
       "integrity": "sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==",
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-safe-parser": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.1.tgz",
+      "integrity": "sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss-safe-parser"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.31"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/qified": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/qified/-/qified-0.6.0.tgz",
+      "integrity": "sha512-tsSGN1x3h569ZSU1u6diwhltLyfUWDp3YbFHedapTmpBl0B3P6U3+Qptg7xu+v+1io1EwhdPyyRHYbEw0KN2FA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^1.14.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/range-parser": {
@@ -730,6 +1783,51 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safe-buffer": {
@@ -828,6 +1926,63 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
     },
+    "node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
@@ -878,6 +2033,159 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stylelint": {
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-17.4.0.tgz",
+      "integrity": "sha512-3kQ2/cHv3Zt8OBg+h2B8XCx9evEABQIrv4hh3uXahGz/ZEHrTR80zxBiK2NfXNaSoyBzxO1pjsz1Vhdzwn5XSw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/stylelint"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/stylelint"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.27",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "@csstools/media-query-list-parser": "^5.0.0",
+        "@csstools/selector-resolve-nested": "^4.0.0",
+        "@csstools/selector-specificity": "^6.0.0",
+        "colord": "^2.9.3",
+        "cosmiconfig": "^9.0.0",
+        "css-functions-list": "^3.3.3",
+        "css-tree": "^3.1.0",
+        "debug": "^4.4.3",
+        "fast-glob": "^3.3.3",
+        "fastest-levenshtein": "^1.0.16",
+        "file-entry-cache": "^11.1.2",
+        "global-modules": "^2.0.0",
+        "globby": "^16.1.0",
+        "globjoin": "^0.1.4",
+        "html-tags": "^5.1.0",
+        "ignore": "^7.0.5",
+        "import-meta-resolve": "^4.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-plain-object": "^5.0.0",
+        "mathml-tag-names": "^4.0.0",
+        "meow": "^14.0.0",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.5.6",
+        "postcss-safe-parser": "^7.0.1",
+        "postcss-selector-parser": "^7.1.1",
+        "postcss-value-parser": "^4.2.0",
+        "string-width": "^8.1.1",
+        "supports-hyperlinks": "^4.4.0",
+        "svg-tags": "^1.0.0",
+        "table": "^6.9.0",
+        "write-file-atomic": "^7.0.0"
+      },
+      "bin": {
+        "stylelint": "bin/stylelint.mjs"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/stylelint-config-recommended": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-18.0.0.tgz",
+      "integrity": "sha512-mxgT2XY6YZ3HWWe3Di8umG6aBmWmHTblTgu/f10rqFXnyWxjKWwNdjSWkgkwCtxIKnqjSJzvFmPT5yabVIRxZg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/stylelint"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/stylelint"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "stylelint": "^17.0.0"
+      }
+    },
+    "node_modules/stylelint-config-standard": {
+      "version": "40.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-40.0.0.tgz",
+      "integrity": "sha512-EznGJxOUhtWck2r6dJpbgAdPATIzvpLdK9+i5qPd4Lx70es66TkBPljSg4wN3Qnc6c4h2n+WbUrUynQ3fanjHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/stylelint"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/stylelint"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "stylelint-config-recommended": "^18.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "stylelint": "^17.0.0"
+      }
+    },
+    "node_modules/stylelint/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/stylelint/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stylelint/node_modules/string-width": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
+      "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -888,6 +2196,130 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/supports-hyperlinks": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-4.4.0.tgz",
+      "integrity": "sha512-UKbpT93hN5Nr9go5UY7bopIB9YQlMz9nm/ct4IXt/irb5YRkn9WaqrOBJGZ5Pwvsd5FQzSVeYlGdXoCAPQZrPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^5.0.1",
+        "supports-color": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
+      }
+    },
+    "node_modules/supports-hyperlinks/node_modules/has-flag": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-5.0.1.tgz",
+      "integrity": "sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-hyperlinks/node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/svg-tags": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
+      "integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==",
+      "dev": true
+    },
+    "node_modules/table": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
+      "integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/table/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/table/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/type-fest": {
@@ -902,6 +2334,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/unicorn-magic": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
+      "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/update-check": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/update-check/-/update-check-1.5.4.tgz",
@@ -911,6 +2356,13 @@
         "registry-auth-token": "3.3.2",
         "registry-url": "3.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -966,6 +2418,32 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/write-file-atomic": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-7.0.1.tgz",
+      "integrity": "sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/write-file-atomic/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -10,5 +10,9 @@
   },
   "dependencies": {
     "serve": "^14.2.4"
+  },
+  "devDependencies": {
+    "stylelint": "^17.4.0",
+    "stylelint-config-standard": "^40.0.0"
   }
 }


### PR DESCRIPTION
## Blueprint

**Approach:** Complete redesign of the Contoso Ltd static site into a premium dark-mode SaaS dashboard. The worker will first audit the existing docs/index.html and docs/styles.css to extract all data and structure, then rebuild with Tailwind CSS (via CDN — no build step required, compatible with GitHub Pages deployment). The design language will be dark slate/charcoal backgrounds with indigo/violet accent colors, glass-morphism card effects, and clean typography. All existing data content will be preserved and re-presented in modern dashboard widgets. The site remains pure static HTML/CSS/JS with no backend changes. Mobile responsiveness is a lower priority for this demo but basic breakpoint support will be included via Tailwind utility classes. The deploy pipeline (.github/workflows/deploy.yml) is untouched.

### Milestones
1. **Audit existing content and data** — Read the full contents of docs/index.html and docs/styles.css to catalogue every data element, section, table, link, and interactive component currently on the page. Produce an internal inventory of all content that must be preserved in the redesign. This milestone is a discovery/planning step — no files are modified yet. The worker should document findings as inline comments in the new template structure.
   - All sections of docs/index.html have been read and catalogued (topbar, navigation, data tables, sidebar panels, footers, any scripts)
   - All CSS class names and layout structure from docs/styles.css are understood
   - An internal content inventory exists (as comments or notes) that will guide milestone 2
2. **Rebuild docs/index.html with Tailwind CDN and dark-mode dashboard layout** — Replace the existing docs/index.html with a fully redesigned dark-mode dashboard. Use Tailwind CSS via CDN (play.tailwindcss.com CDN script or cdn.tailwindcss.com). Layout: fixed left sidebar with navigation, top header bar with breadcrumb/user avatar area, and a main content area with card-based widgets. Color palette: background slate-900/slate-800, cards slate-800/slate-700, accents indigo-500/violet-500, text slate-100/slate-300. Preserve ALL data content from the existing page — tables, metrics, project names, links, statuses. Add subtle hover effects and transitions via Tailwind classes. Include a small vanilla JS snippet for any interactive elements (sidebar toggle, active nav state).
   - Tailwind CSS is loaded via CDN — no npm build step required
   - Page renders correctly when served via 'npx serve docs' or directly opening the HTML file
   - Dark mode color scheme is applied: slate-900 background, indigo accent colors, no white/light backgrounds
   - Left sidebar is present with navigation links matching the original site sections
   - Top header bar includes the Contoso branding and a user/session indicator area
   - All original data content (tables, metrics, project names, statuses, links) from the old index.html is present and readable
   - Cards/panels use a consistent glass-morphism or elevated dark card style with subtle borders
   - Page is valid HTML5 and passes basic browser rendering without console errors
3. **Rewrite docs/styles.css for supplemental custom styles** — Since Tailwind handles most styling, docs/styles.css should be trimmed to only custom styles that Tailwind cannot express inline: custom scrollbar styling, CSS animations (pulse, shimmer effects), glass-morphism backdrop-filter, font imports (e.g. Inter from Google Fonts), and any legacy overrides. Remove all old table-based layout styles. The file should be lean and purposeful.
   - docs/styles.css no longer contains any table-based layout rules or legacy CSS from the original design
   - Custom scrollbar styles are defined for webkit browsers (dark, slim scrollbar matching the theme)
   - Inter or equivalent premium sans-serif font is imported and applied as the base font
   - Any CSS animations (fade-in, shimmer, pulse for status indicators) are defined
   - Glass-morphism utility class (backdrop-blur, semi-transparent background) is defined if used in index.html
   - File is less than 150 lines — Tailwind handles the rest
4. **Polish: dashboard widgets, micro-interactions, and final QA** — Elevate the design with premium SaaS polish. Add: (1) KPI summary cards at the top of the main content area showing key metrics extracted from the existing data (e.g. total projects, active tasks, completion rate), (2) status badges with colored dots for project/task states, (3) a subtle sidebar active-state highlight, (4) smooth CSS transitions on hover for cards and buttons, (5) a sticky header that stays visible on scroll. Perform end-to-end QA: verify all original data is preserved, no broken links, no console errors, and the page looks premium when opened in Chrome/Firefox.
   - At least 3 KPI summary cards appear at the top of the main content area with real data values from the original site
   - Status indicators (colored dot + label) are used for any project/task status fields
   - Sidebar navigation highlights the active/current page item
   - Card hover states include a subtle border-color or shadow transition (150–200ms ease)
   - Page header is sticky and remains visible when scrolling the main content area
   - All links from the original page are preserved and functional
   - No JavaScript console errors on page load
   - Visual review confirms the page looks like a premium dark SaaS dashboard, not a legacy HTML page
   - node_modules is NOT committed — .gitignore contains 'node_modules/' entry

---
_Automated by Hive - Task HIVE-20260311-f7bc0cb4_