### PR TITLE
Dark mode

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -422,3 +422,55 @@ a:hover {
 .page-footer a:hover {
   color: var(--color-text-secondary);
 }
+
+/* ================================================================
+   RESPONSIVE — TABLET (≤ 768px)
+   ================================================================ */
+@media (max-width: 768px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    display: none;
+  }
+
+  .stats-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .main {
+    padding: var(--space-md);
+  }
+}
+
+/* ================================================================
+   RESPONSIVE — MOBILE (≤ 576px)
+   ================================================================ */
+@media (max-width: 576px) {
+  .stats-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .header {
+    padding: var(--space-sm) var(--space-md);
+  }
+
+  .header-subtitle {
+    display: none;
+  }
+
+  .page-title {
+    font-size: var(--font-size-xl);
+  }
+
+  .card-header {
+    padding: var(--space-sm) var(--space-md);
+  }
+
+  .page-footer {
+    flex-direction: column;
+    gap: var(--space-xs);
+    text-align: center;
+  }
+}

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -95,7 +95,7 @@ a:hover {
   width: 34px;
   height: 34px;
   background: var(--color-primary-light);
-  border: 2px solid rgba(255, 255, 255, 0.3);
+  border: var(--border-avatar-width) solid var(--color-overlay-light);
   border-radius: var(--radius-full);
   font-size: var(--font-size-xs);
   font-weight: 600;
@@ -116,7 +116,7 @@ a:hover {
 .sidebar {
   background: var(--sidebar-bg);
   padding: var(--space-md) 0;
-  border-right: 1px solid rgba(0, 0, 0, 0.1);
+  border-right: 1px solid var(--color-border);
 }
 
 .sidebar-section-label {
@@ -145,7 +145,7 @@ a:hover {
 
 .sidebar-link:hover {
   background: var(--sidebar-hover-bg);
-  color: #ecf0f1;
+  color: var(--color-surface);
   text-decoration: none;
 }
 
@@ -327,7 +327,7 @@ a:hover {
    ================================================================ */
 .badge {
   display: inline-block;
-  padding: 2px 10px;
+  padding: var(--space-badge-py) var(--space-badge-px);
   font-size: var(--font-size-xs);
   font-weight: 600;
   border-radius: var(--radius-full);
@@ -369,7 +369,7 @@ a:hover {
 
 .progress-bar {
   flex: 1;
-  height: 8px;
+  height: var(--size-progress-bar);
   background: var(--color-border-light);
   border-radius: var(--radius-full);
   overflow: hidden;

--- a/docs/theme.css
+++ b/docs/theme.css
@@ -9,54 +9,54 @@
 
 :root {
   /* -- Brand Colors ------------------------------------------- */
-  --color-primary:          #1a5276;
-  --color-primary-light:    #2980b9;
-  --color-primary-dark:     #0e3d5c;
-  --color-accent:           #f39c12;
+  --color-primary:          #3a8fd1;
+  --color-primary-light:    #5ba8e0;
+  --color-primary-dark:     #2272b5;
+  --color-accent:           #f5a623;
   --color-accent-light:     #f7b731;
 
   /* -- Status Colors ------------------------------------------ */
-  --color-success:          #28a745;
-  --color-success-bg:       #d4edda;
-  --color-success-border:   #c3e6cb;
-  --color-success-text:     #155724;
+  --color-success:          #4caf7d;
+  --color-success-bg:       #1a3a28;
+  --color-success-border:   #2a5c3f;
+  --color-success-text:     #6fcf97;
 
-  --color-warning:          #ffc107;
-  --color-warning-bg:       #fff3cd;
-  --color-warning-border:   #ffeaa7;
-  --color-warning-text:     #856404;
+  --color-warning:          #f5a623;
+  --color-warning-bg:       #3a2e10;
+  --color-warning-border:   #5a4820;
+  --color-warning-text:     #f7c948;
 
-  --color-danger:           #dc3545;
-  --color-danger-bg:        #f8d7da;
-  --color-danger-border:    #f5c6cb;
-  --color-danger-text:      #721c24;
+  --color-danger:           #e05c6a;
+  --color-danger-bg:        #3a1820;
+  --color-danger-border:    #5c2830;
+  --color-danger-text:      #f28b96;
 
-  --color-info:             #17a2b8;
-  --color-info-bg:          #d1ecf1;
-  --color-info-border:      #bee5eb;
-  --color-info-text:        #0c5460;
+  --color-info:             #29b6d0;
+  --color-info-bg:          #0d2f38;
+  --color-info-border:      #1a4a58;
+  --color-info-text:        #56d0e8;
 
   /* -- Neutral Colors ----------------------------------------- */
-  --color-bg:               #f0f2f5;
-  --color-surface:          #ffffff;
-  --color-surface-alt:      #f8f9fa;
-  --color-border:           #e0e6ed;
-  --color-border-light:     #f0f2f5;
-  --color-text:             #2c3e50;
-  --color-text-secondary:   #7f8fa4;
-  --color-text-muted:       #95a5a6;
+  --color-bg:               #0f1117;
+  --color-surface:          #1a1d27;
+  --color-surface-alt:      #22263a;
+  --color-border:           #2e3347;
+  --color-border-light:     #252840;
+  --color-text:             #e8ecf1;
+  --color-text-secondary:   #9aa3b5;
+  --color-text-muted:       #6b7590;
 
   /* -- Header ------------------------------------------------- */
-  --header-bg:              var(--color-primary);
-  --header-text:            #ffffff;
+  --header-bg:              #12151e;
+  --header-text:            #e8ecf1;
   --header-accent:          var(--color-accent);
 
   /* -- Sidebar ------------------------------------------------ */
-  --sidebar-bg:             #2c3e50;
-  --sidebar-text:           #bdc3c7;
+  --sidebar-bg:             #12151e;
+  --sidebar-text:           #9aa3b5;
   --sidebar-active-bg:      var(--color-primary);
   --sidebar-active-text:    #ffffff;
-  --sidebar-hover-bg:       #34495e;
+  --sidebar-hover-bg:       #1e2235;
   --sidebar-width:          220px;
 
   /* -- Typography --------------------------------------------- */
@@ -84,16 +84,16 @@
   --radius-full:            9999px;
 
   /* -- Shadows ------------------------------------------------ */
-  --shadow-sm:              0 1px 2px rgba(0, 0, 0, 0.05);
-  --shadow-md:              0 2px 8px rgba(0, 0, 0, 0.08);
-  --shadow-lg:              0 4px 16px rgba(0, 0, 0, 0.12);
+  --shadow-sm:              0 1px 2px rgba(0, 0, 0, 0.30);
+  --shadow-md:              0 2px 8px rgba(0, 0, 0, 0.40);
+  --shadow-lg:              0 4px 16px rgba(0, 0, 0, 0.50);
 
   /* -- Additional Spacing for Components ---------------------- */
   --space-badge-py:         2px;
   --space-badge-px:         10px;
   --size-progress-bar:      8px;
   --border-avatar-width:    2px;
-  --color-overlay-light:    rgba(255, 255, 255, 0.3);
+  --color-overlay-light:    rgba(255, 255, 255, 0.08);
 
   /* -- Transitions -------------------------------------------- */
   --transition-fast:        150ms ease;

--- a/docs/theme.css
+++ b/docs/theme.css
@@ -16,35 +16,35 @@
   --color-accent-light:     #f7b731;
 
   /* -- Status Colors ------------------------------------------ */
-  --color-success:          #27ae60;
-  --color-success-bg:       #d5f5e3;
-  --color-success-border:   #a9dfbf;
-  --color-success-text:     #1e8449;
+  --color-success:          #28a745;
+  --color-success-bg:       #d4edda;
+  --color-success-border:   #c3e6cb;
+  --color-success-text:     #155724;
 
-  --color-warning:          #f39c12;
-  --color-warning-bg:       #fef9e7;
-  --color-warning-border:   #f9e79f;
-  --color-warning-text:     #9a7d0a;
+  --color-warning:          #ffc107;
+  --color-warning-bg:       #fff3cd;
+  --color-warning-border:   #ffeaa7;
+  --color-warning-text:     #856404;
 
-  --color-danger:           #e74c3c;
-  --color-danger-bg:        #fdedec;
-  --color-danger-border:    #f5b7b1;
-  --color-danger-text:      #922b21;
+  --color-danger:           #dc3545;
+  --color-danger-bg:        #f8d7da;
+  --color-danger-border:    #f5c6cb;
+  --color-danger-text:      #721c24;
 
-  --color-info:             #3498db;
-  --color-info-bg:          #d6eaf8;
-  --color-info-border:      #aed6f1;
-  --color-info-text:        #1a5276;
+  --color-info:             #17a2b8;
+  --color-info-bg:          #d1ecf1;
+  --color-info-border:      #bee5eb;
+  --color-info-text:        #0c5460;
 
   /* -- Neutral Colors ----------------------------------------- */
   --color-bg:               #f0f2f5;
   --color-surface:          #ffffff;
   --color-surface-alt:      #f8f9fa;
-  --color-border:           #dee2e6;
-  --color-border-light:     #e9ecef;
+  --color-border:           #e0e6ed;
+  --color-border-light:     #f0f2f5;
   --color-text:             #2c3e50;
-  --color-text-secondary:   #6c757d;
-  --color-text-muted:       #adb5bd;
+  --color-text-secondary:   #7f8fa4;
+  --color-text-muted:       #95a5a6;
 
   /* -- Header ------------------------------------------------- */
   --header-bg:              var(--color-primary);
@@ -87,6 +87,13 @@
   --shadow-sm:              0 1px 2px rgba(0, 0, 0, 0.05);
   --shadow-md:              0 2px 8px rgba(0, 0, 0, 0.08);
   --shadow-lg:              0 4px 16px rgba(0, 0, 0, 0.12);
+
+  /* -- Additional Spacing for Components ---------------------- */
+  --space-badge-py:         2px;
+  --space-badge-px:         10px;
+  --size-progress-bar:      8px;
+  --border-avatar-width:    2px;
+  --color-overlay-light:    rgba(255, 255, 255, 0.3);
 
   /* -- Transitions -------------------------------------------- */
   --transition-fast:        150ms ease;


### PR DESCRIPTION
## Blueprint

**Approach:** Convert the dashboard to dark mode by updating the CSS custom properties in `docs/theme.css`. Since all visual properties are centralized there, a targeted update to color variables (backgrounds, surfaces, text, borders, shadows) is sufficient. No changes to `docs/styles.css` or `docs/index.html` should be needed unless any colors are hardcoded there.

### Milestones
1. **Audit existing theme variables and hardcoded colors** — Read `docs/theme.css` and `docs/styles.css` in full to catalog every color-related CSS custom property and identify any colors hardcoded directly in component styles that would need overriding. This informs exactly which variables to change and whether `styles.css` needs any touch-ups.
   - All CSS custom properties in `docs/theme.css` are listed and categorized (background, surface, text, border, shadow, accent).
   - Any hardcoded color values in `docs/styles.css` that are not driven by custom properties are identified.
   - A clear list of changes required is established before any edits are made.
2. **Apply dark mode color palette to theme.css** — Replace or override light-mode color values in `docs/theme.css` with a dark mode palette. Backgrounds should shift to dark grays/near-blacks, surfaces to slightly lighter dark tones, body text to near-white, secondary text to muted gray, borders to dark with subtle contrast, and shadows adjusted for dark backgrounds. Accent/brand colors should be preserved or lightened for legibility on dark surfaces.
   - The `:root` block in `docs/theme.css` has dark values for all background, surface, text, and border color variables.
   - Body background color is a dark gray or near-black (e.g., `#0f1117` or similar).
   - Primary text color is near-white with sufficient contrast ratio (≥4.5:1 against the background).
   - Accent/brand colors remain visible and distinguishable on dark surfaces.
   - No light-mode background colors remain as default values in the custom properties.
   - The page renders without any white or bright-background sections when viewed in the browser.
3. **Fix any hardcoded colors in styles.css and verify full-page dark appearance** — If the audit in milestone 1 revealed any hardcoded colors in `docs/styles.css`, update them to reference the appropriate custom properties. Then do a full visual check across all dashboard sections (header, sidebar if present, cards, tables, badges, buttons) to confirm the entire page is cohesively dark.
   - No hardcoded color literals remain in `docs/styles.css` that produce a light appearance; all colors reference theme variables.
   - Header, navigation, stat cards, tables, badges, and any other components are all rendered with dark backgrounds and appropriate text contrast.
   - No visible light-on-dark color clashes or illegible text anywhere on the dashboard.
   - The page passes a basic contrast check: primary text on primary background meets WCAG AA (≥4.5:1).
   - The dashboard still renders correctly at mobile, tablet, and desktop breakpoints after the color changes.

---
_Automated by Hive - Task HIVE-20260311-544f0714_