### PR TITLE
[#9] Add new stat card

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -84,6 +84,11 @@
           <div class="stat-value stat-danger">1</div>
           <div class="stat-trend">Needs attention</div>
         </div>
+        <div class="stat-card">
+          <div class="stat-label">Total Budget</div>
+          <div class="stat-value">$1.5M</div>
+          <div class="stat-trend">Q1 2026 allocation</div>
+        </div>
       </section>
 
       <!-- ==================================================

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -187,9 +187,27 @@ a:hover {
    ================================================================ */
 .stats-grid {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(5, 1fr);
   gap: var(--space-lg);
   margin-bottom: var(--space-xl);
+}
+
+@media (max-width: 1024px) {
+  .stats-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (max-width: 768px) {
+  .stats-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 480px) {
+  .stats-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 .stat-card {


### PR DESCRIPTION
## Blueprint

**Approach:** Add a new 'Total Budget: $1.5M' stat card to the existing stats section in docs/index.html, following the same HTML structure and CSS classes used by the existing stat cards.

**Key files:** `docs/index.html`, `docs/styles.css`, `docs/theme.css`

### Checklist
- [ ] Inspect the existing stat card HTML structure in docs/index.html to identify the correct element/class pattern used
- [ ] Add a new stat card element with label 'Total Budget' and value '$1.5M' inside the stats section, using the same markup pattern as existing cards
- [ ] Verify docs/styles.css already has styles covering the stat card class; add styles only if the new card requires a new variant or modifier class
- [ ] Confirm the new card renders visibly in the stats grid alongside existing cards (no overflow, correct spacing)
- [ ] Verify the card is responsive and stacks correctly on mobile (per existing grid CSS media queries)

---
_Automated by Hive - Task HIVE-20260312-522d4a60_