### PR TITLE
[#12] Dark mode

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -95,7 +95,7 @@ a:hover {
   width: 34px;
   height: 34px;
   background: var(--color-primary-light);
-  border: 2px solid rgba(255, 255, 255, 0.3);
+  border: 2px solid var(--color-border);
   border-radius: var(--radius-full);
   font-size: var(--font-size-xs);
   font-weight: 600;
@@ -116,7 +116,7 @@ a:hover {
 .sidebar {
   background: var(--sidebar-bg);
   padding: var(--space-md) 0;
-  border-right: 1px solid rgba(0, 0, 0, 0.1);
+  border-right: 1px solid var(--color-border);
 }
 
 .sidebar-section-label {
@@ -145,7 +145,7 @@ a:hover {
 
 .sidebar-link:hover {
   background: var(--sidebar-hover-bg);
-  color: #ecf0f1;
+  color: var(--sidebar-active-text);
   text-decoration: none;
 }
 

--- a/docs/theme.css
+++ b/docs/theme.css
@@ -9,54 +9,54 @@
 
 :root {
   /* -- Brand Colors ------------------------------------------- */
-  --color-primary:          #1a5276;
-  --color-primary-light:    #2980b9;
-  --color-primary-dark:     #0e3d5c;
+  --color-primary:          #4a9eda;
+  --color-primary-light:    #6ab4e8;
+  --color-primary-dark:     #2d7ab5;
   --color-accent:           #f39c12;
   --color-accent-light:     #f7b731;
 
   /* -- Status Colors ------------------------------------------ */
-  --color-success:          #27ae60;
-  --color-success-bg:       #d5f5e3;
-  --color-success-border:   #a9dfbf;
-  --color-success-text:     #1e8449;
+  --color-success:          #2ecc71;
+  --color-success-bg:       #0d2e1a;
+  --color-success-border:   #1a5c34;
+  --color-success-text:     #2ecc71;
 
   --color-warning:          #f39c12;
-  --color-warning-bg:       #fef9e7;
-  --color-warning-border:   #f9e79f;
-  --color-warning-text:     #9a7d0a;
+  --color-warning-bg:       #2e1f04;
+  --color-warning-border:   #7a4f08;
+  --color-warning-text:     #f5a623;
 
   --color-danger:           #e74c3c;
-  --color-danger-bg:        #fdedec;
-  --color-danger-border:    #f5b7b1;
-  --color-danger-text:      #922b21;
+  --color-danger-bg:        #2e0d0a;
+  --color-danger-border:    #7a1f18;
+  --color-danger-text:      #e74c3c;
 
   --color-info:             #3498db;
-  --color-info-bg:          #d6eaf8;
-  --color-info-border:      #aed6f1;
-  --color-info-text:        #1a5276;
+  --color-info-bg:          #0a1e2e;
+  --color-info-border:      #1a4a6e;
+  --color-info-text:        #6ab4e8;
 
   /* -- Neutral Colors ----------------------------------------- */
-  --color-bg:               #f0f2f5;
-  --color-surface:          #ffffff;
-  --color-surface-alt:      #f8f9fa;
-  --color-border:           #dee2e6;
-  --color-border-light:     #e9ecef;
-  --color-text:             #2c3e50;
-  --color-text-secondary:   #6c757d;
-  --color-text-muted:       #adb5bd;
+  --color-bg:               #0f1117;
+  --color-surface:          #1a1d27;
+  --color-surface-alt:      #222532;
+  --color-border:           #2e3244;
+  --color-border-light:     #252839;
+  --color-text:             #e2e8f0;
+  --color-text-secondary:   #94a3b8;
+  --color-text-muted:       #64748b;
 
   /* -- Header ------------------------------------------------- */
-  --header-bg:              var(--color-primary);
-  --header-text:            #ffffff;
+  --header-bg:              #131520;
+  --header-text:            #e2e8f0;
   --header-accent:          var(--color-accent);
 
   /* -- Sidebar ------------------------------------------------ */
-  --sidebar-bg:             #2c3e50;
-  --sidebar-text:           #bdc3c7;
-  --sidebar-active-bg:      var(--color-primary);
-  --sidebar-active-text:    #ffffff;
-  --sidebar-hover-bg:       #34495e;
+  --sidebar-bg:             #131520;
+  --sidebar-text:           #94a3b8;
+  --sidebar-active-bg:      #1e3a5f;
+  --sidebar-active-text:    #e2e8f0;
+  --sidebar-hover-bg:       #1e2235;
   --sidebar-width:          220px;
 
   /* -- Typography --------------------------------------------- */
@@ -84,9 +84,9 @@
   --radius-full:            9999px;
 
   /* -- Shadows ------------------------------------------------ */
-  --shadow-sm:              0 1px 2px rgba(0, 0, 0, 0.05);
-  --shadow-md:              0 2px 8px rgba(0, 0, 0, 0.08);
-  --shadow-lg:              0 4px 16px rgba(0, 0, 0, 0.12);
+  --shadow-sm:              0 1px 2px rgba(0, 0, 0, 0.4);
+  --shadow-md:              0 2px 8px rgba(0, 0, 0, 0.5);
+  --shadow-lg:              0 4px 16px rgba(0, 0, 0, 0.6);
 
   /* -- Transitions -------------------------------------------- */
   --transition-fast:        150ms ease;

--- a/docs/theme.css
+++ b/docs/theme.css
@@ -12,26 +12,26 @@
   --color-primary:          #4a9eda;
   --color-primary-light:    #6ab4e8;
   --color-primary-dark:     #2d7ab5;
-  --color-accent:           #f39c12;
-  --color-accent-light:     #f7b731;
+  --color-accent:           #f5a623;
+  --color-accent-light:     #f7c05a;
 
   /* -- Status Colors ------------------------------------------ */
-  --color-success:          #2ecc71;
+  --color-success:          #3dd68c;
   --color-success-bg:       #0d2e1a;
   --color-success-border:   #1a5c34;
-  --color-success-text:     #2ecc71;
+  --color-success-text:     #3dd68c;
 
-  --color-warning:          #f39c12;
+  --color-warning:          #f5a623;
   --color-warning-bg:       #2e1f04;
   --color-warning-border:   #7a4f08;
-  --color-warning-text:     #f5a623;
+  --color-warning-text:     #f7c05a;
 
-  --color-danger:           #e74c3c;
+  --color-danger:           #f06a5d;
   --color-danger-bg:        #2e0d0a;
   --color-danger-border:    #7a1f18;
-  --color-danger-text:      #e74c3c;
+  --color-danger-text:      #f06a5d;
 
-  --color-info:             #3498db;
+  --color-info:             #4a9eda;
   --color-info-bg:          #0a1e2e;
   --color-info-border:      #1a4a6e;
   --color-info-text:        #6ab4e8;
@@ -84,9 +84,9 @@
   --radius-full:            9999px;
 
   /* -- Shadows ------------------------------------------------ */
-  --shadow-sm:              0 1px 2px rgba(0, 0, 0, 0.4);
-  --shadow-md:              0 2px 8px rgba(0, 0, 0, 0.5);
-  --shadow-lg:              0 4px 16px rgba(0, 0, 0, 0.6);
+  --shadow-sm:              0 1px 3px rgba(0, 0, 0, 0.5);
+  --shadow-md:              0 4px 12px rgba(0, 0, 0, 0.6);
+  --shadow-lg:              0 8px 24px rgba(0, 0, 0, 0.7);
 
   /* -- Transitions -------------------------------------------- */
   --transition-fast:        150ms ease;


### PR DESCRIPTION
## Blueprint

**Approach:** Convert the dashboard to dark mode by updating CSS custom properties in docs/theme.css. The theming system is already built around CSS custom properties, so this is a focused change: redefine color variables to dark palette values and verify all components render correctly. No structural HTML changes are needed.

### Milestones
1. **Audit existing theme variables** — Read docs/theme.css in full to catalogue all CSS custom properties (colors, backgrounds, borders, shadows, text colors) currently defined. Also read docs/styles.css to understand how those variables are consumed by components. This audit ensures no variable is missed when switching to dark mode.
   - All CSS custom properties in docs/theme.css are identified and listed
   - All variable usages in docs/styles.css are cross-referenced so no color token is left with a light-mode value
2. **Apply dark mode palette to theme.css** — Replace light-mode color values in docs/theme.css with a coherent dark mode palette. Typical changes: background colors shift to dark grays/near-blacks (e.g. #0f1117, #1a1d27, #242736), surface/card colors to mid-dark grays, text colors to near-whites and light grays, border colors to subtle dark borders, and accent/brand colors adjusted for legibility on dark backgrounds. Shadows should be updated to work on dark surfaces (e.g. use darker shadow colors with slightly higher opacity). Keep all variable names identical so styles.css requires no changes.
   - Every color-related custom property in docs/theme.css has been updated to a dark-mode value
   - Background colors are dark (visually close to black or very dark gray)
   - Text colors provide sufficient contrast against dark backgrounds (WCAG AA: ≥4.5:1 for normal text)
   - Accent/brand colors remain visually distinguishable on dark backgrounds
   - No light-mode background or surface color remains unchanged
   - docs/styles.css is not modified (all changes are contained to theme.css)
3. **Verify full dashboard render in dark mode** — Load the dashboard in a browser (npm run dev → http://localhost:3000) and inspect every component: header, sidebar/nav, cards, tables, badges, buttons, and any status indicators. Confirm no component has hardcoded colors in styles.css or index.html that override the theme variables, leaving a light-mode artifact. Fix any such hardcoded values by converting them to theme variable references.
   - Dashboard loads at http://localhost:3000 with a fully dark background
   - Header, navigation, cards, tables, and all UI components display dark-mode colors with no light-mode artifacts
   - All text is legible against its background (no black text on dark background)
   - No inline styles or hardcoded hex/rgb color values remain in docs/index.html that conflict with dark theme
   - Any hardcoded colors found in docs/styles.css have been converted to CSS custom property references

---
_Automated by Hive - Task HIVE-20260313-f7029d32_