### PR TITLE
[#12] Dark mode

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="color-scheme" content="dark">
   <title>Contoso Ltd — Project Dashboard</title>
   <link rel="stylesheet" href="theme.css">
   <link rel="stylesheet" href="styles.css">

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -95,7 +95,7 @@ a:hover {
   width: 34px;
   height: 34px;
   background: var(--color-primary-light);
-  border: 2px solid rgba(255, 255, 255, 0.3);
+  border: 2px solid var(--header-avatar-border);
   border-radius: var(--radius-full);
   font-size: var(--font-size-xs);
   font-weight: 600;
@@ -116,7 +116,7 @@ a:hover {
 .sidebar {
   background: var(--sidebar-bg);
   padding: var(--space-md) 0;
-  border-right: 1px solid rgba(0, 0, 0, 0.1);
+  border-right: 1px solid var(--sidebar-border);
 }
 
 .sidebar-section-label {
@@ -145,7 +145,7 @@ a:hover {
 
 .sidebar-link:hover {
   background: var(--sidebar-hover-bg);
-  color: #ecf0f1;
+  color: var(--sidebar-hover-text);
   text-decoration: none;
 }
 

--- a/docs/theme.css
+++ b/docs/theme.css
@@ -37,6 +37,7 @@
   --color-info-text:        #7ec4f0;
 
   /* -- Neutral Colors ----------------------------------------- */
+  --color-white:            #ffffff;
   --color-bg:               #0f1117;
   --color-surface:          #1a1d27;
   --color-surface-alt:      #22263a;
@@ -50,13 +51,16 @@
   --header-bg:              #141720;
   --header-text:            #e8eaf0;
   --header-accent:          var(--color-accent);
+  --header-avatar-border:   rgba(255, 255, 255, 0.3);
 
   /* -- Sidebar ------------------------------------------------ */
   --sidebar-bg:             #141720;
   --sidebar-text:           #9aa0b8;
   --sidebar-active-bg:      var(--color-primary-dark);
-  --sidebar-active-text:    #ffffff;
+  --sidebar-active-text:    var(--color-white);
   --sidebar-hover-bg:       #1e2235;
+  --sidebar-hover-text:     #ecf0f1;
+  --sidebar-border:         rgba(0, 0, 0, 0.1);
   --sidebar-width:          220px;
 
   /* -- Typography --------------------------------------------- */

--- a/docs/theme.css
+++ b/docs/theme.css
@@ -9,54 +9,54 @@
 
 :root {
   /* -- Brand Colors ------------------------------------------- */
-  --color-primary:          #1a5276;
-  --color-primary-light:    #2980b9;
-  --color-primary-dark:     #0e3d5c;
-  --color-accent:           #f39c12;
-  --color-accent-light:     #f7b731;
+  --color-primary:          #4a9eda;
+  --color-primary-light:    #6ab4e8;
+  --color-primary-dark:     #2e7ab8;
+  --color-accent:           #f5a623;
+  --color-accent-light:     #f7bb4f;
 
   /* -- Status Colors ------------------------------------------ */
-  --color-success:          #27ae60;
-  --color-success-bg:       #d5f5e3;
-  --color-success-border:   #a9dfbf;
-  --color-success-text:     #1e8449;
+  --color-success:          #2ecc71;
+  --color-success-bg:       #0d2b1a;
+  --color-success-border:   #1a5c35;
+  --color-success-text:     #5de898;
 
-  --color-warning:          #f39c12;
-  --color-warning-bg:       #fef9e7;
-  --color-warning-border:   #f9e79f;
-  --color-warning-text:     #9a7d0a;
+  --color-warning:          #f5a623;
+  --color-warning-bg:       #2b1f08;
+  --color-warning-border:   #5c3d10;
+  --color-warning-text:     #f7c96a;
 
-  --color-danger:           #e74c3c;
-  --color-danger-bg:        #fdedec;
-  --color-danger-border:    #f5b7b1;
-  --color-danger-text:      #922b21;
+  --color-danger:           #e05c4b;
+  --color-danger-bg:        #2b0e0a;
+  --color-danger-border:    #5c2018;
+  --color-danger-text:      #f08070;
 
-  --color-info:             #3498db;
-  --color-info-bg:          #d6eaf8;
-  --color-info-border:      #aed6f1;
-  --color-info-text:        #1a5276;
+  --color-info:             #4a9eda;
+  --color-info-bg:          #0a1e2b;
+  --color-info-border:      #1a3d5c;
+  --color-info-text:        #7ec4f0;
 
   /* -- Neutral Colors ----------------------------------------- */
-  --color-bg:               #f0f2f5;
-  --color-surface:          #ffffff;
-  --color-surface-alt:      #f8f9fa;
-  --color-border:           #dee2e6;
-  --color-border-light:     #e9ecef;
-  --color-text:             #2c3e50;
-  --color-text-secondary:   #6c757d;
-  --color-text-muted:       #adb5bd;
+  --color-bg:               #0f1117;
+  --color-surface:          #1a1d27;
+  --color-surface-alt:      #22263a;
+  --color-border:           #2e3347;
+  --color-border-light:     #252840;
+  --color-text:             #e8eaf0;
+  --color-text-secondary:   #9aa0b8;
+  --color-text-muted:       #5c6380;
 
   /* -- Header ------------------------------------------------- */
-  --header-bg:              var(--color-primary);
-  --header-text:            #ffffff;
+  --header-bg:              #141720;
+  --header-text:            #e8eaf0;
   --header-accent:          var(--color-accent);
 
   /* -- Sidebar ------------------------------------------------ */
-  --sidebar-bg:             #2c3e50;
-  --sidebar-text:           #bdc3c7;
-  --sidebar-active-bg:      var(--color-primary);
+  --sidebar-bg:             #141720;
+  --sidebar-text:           #9aa0b8;
+  --sidebar-active-bg:      var(--color-primary-dark);
   --sidebar-active-text:    #ffffff;
-  --sidebar-hover-bg:       #34495e;
+  --sidebar-hover-bg:       #1e2235;
   --sidebar-width:          220px;
 
   /* -- Typography --------------------------------------------- */
@@ -84,9 +84,9 @@
   --radius-full:            9999px;
 
   /* -- Shadows ------------------------------------------------ */
-  --shadow-sm:              0 1px 2px rgba(0, 0, 0, 0.05);
-  --shadow-md:              0 2px 8px rgba(0, 0, 0, 0.08);
-  --shadow-lg:              0 4px 16px rgba(0, 0, 0, 0.12);
+  --shadow-sm:              0 1px 2px rgba(0, 0, 0, 0.40);
+  --shadow-md:              0 2px 8px rgba(0, 0, 0, 0.50);
+  --shadow-lg:              0 4px 16px rgba(0, 0, 0, 0.60);
 
   /* -- Transitions -------------------------------------------- */
   --transition-fast:        150ms ease;

--- a/docs/theme.css
+++ b/docs/theme.css
@@ -9,6 +9,7 @@
 
 :root {
   /* -- Brand Colors ------------------------------------------- */
+  /* Dark mode primary: lighter blue for better visibility on dark backgrounds */
   --color-primary:          #4a9eda;
   --color-primary-light:    #6ab4e8;
   --color-primary-dark:     #2e7ab8;
@@ -37,7 +38,7 @@
   --color-info-text:        #7ec4f0;
 
   /* -- Neutral Colors ----------------------------------------- */
-  --color-white:            #ffffff;
+  --color-white:            #ffffff; /* Used for high-contrast text on active elements */
   --color-bg:               #0f1117;
   --color-surface:          #1a1d27;
   --color-surface-alt:      #22263a;
@@ -51,7 +52,7 @@
   --header-bg:              #141720;
   --header-text:            #e8eaf0;
   --header-accent:          var(--color-accent);
-  --header-avatar-border:   rgba(255, 255, 255, 0.3);
+  --header-avatar-border:   rgba(255, 255, 255, 0.15);
 
   /* -- Sidebar ------------------------------------------------ */
   --sidebar-bg:             #141720;
@@ -60,7 +61,7 @@
   --sidebar-active-text:    var(--color-white);
   --sidebar-hover-bg:       #1e2235;
   --sidebar-hover-text:     #ecf0f1;
-  --sidebar-border:         rgba(0, 0, 0, 0.1);
+  --sidebar-border:         rgba(255, 255, 255, 0.1);
   --sidebar-width:          220px;
 
   /* -- Typography --------------------------------------------- */


### PR DESCRIPTION
## Blueprint

**Approach:** Update the dashboard theme to dark mode by modifying the CSS custom properties in docs/theme.css. Since all visual properties are controlled by CSS custom properties in that single file, switching to dark mode is a contained change. We'll update color variables to dark-mode-appropriate values (dark backgrounds, light text, adjusted surface/border colors) while keeping layout, typography scale, spacing, and component structure untouched. A secondary pass will verify no hardcoded colors in styles.css override the theme variables.

### Milestones
1. **Update theme.css with dark mode color palette** — Replace or update the CSS custom property values in docs/theme.css to implement a dark mode palette. This includes background colors (page, surface, card), text colors (primary, secondary, muted), border/separator colors, accent/brand colors adjusted for dark contrast, and shadow values appropriate for dark surfaces. Spacing, font, and radius variables remain unchanged.
   - The :root block in theme.css contains dark background values (e.g. near-black or very dark grey for page background, dark grey for card/surface backgrounds)
   - Text color variables are set to light values (e.g. off-white or light grey for primary text, medium grey for secondary/muted text) ensuring readable contrast
   - Border and separator color variables use dark-appropriate mid-grey values
   - Accent/brand color variables retain recognisable hues but are adjusted (lightened or desaturated if necessary) to meet at least 4.5:1 contrast ratio against dark backgrounds
   - Shadow variables are updated to suit dark surfaces (e.g. reduced opacity or adjusted colour)
   - No layout, spacing, font-size, or border-radius variables are changed
2. **Audit styles.css for hardcoded color overrides** — Review docs/styles.css to identify any hardcoded color values (hex, rgb, named colors) that bypass the theme variables and would make the dark mode look broken. Replace any found hardcoded colors with references to the appropriate CSS custom property defined in theme.css. This milestone depends on the theme variables established in Milestone 1.
   - Every color value in styles.css that previously referenced a hardcoded colour is now expressed as var(--<property-name>) referencing a variable defined in theme.css
   - No new hardcoded color values are introduced
   - The dashboard renders correctly with the dark theme applied — no light-coloured backgrounds or dark text on dark surfaces visible when loading the page in a browser
3. **Visual verification and final checks** — Load the dashboard in the preview environment and verify the dark mode is applied consistently across all visible sections: header, sidebar (if any), stat cards, tables, badges, buttons, and footer. Check that text is legible everywhere and no component appears broken.
   - Page background is visibly dark (not white or light grey) when served via `npx serve docs`
   - All text elements (headings, body copy, labels, table cells) are rendered in light-coloured text with sufficient contrast against their dark backgrounds
   - Interactive elements (buttons, links, badges) are visually distinct and legible in the dark palette
   - No section of the dashboard retains a light/white background that conflicts with the dark theme
   - The page passes a quick browser accessibility contrast check (DevTools or Lighthouse) with no critical contrast failures on primary text

---
_Automated by Hive - Task HIVE-20260313-f0bc95b5_