### PR TITLE
[#17] Overdue project highlight

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -158,7 +158,7 @@
                 <td class="col-right">$156,000</td>
                 <td>Apr 10, 2026</td>
               </tr>
-              <tr>
+              <tr class="row--overdue">
                 <td><a href="#" class="project-name">Legacy CRM Migration</a></td>
                 <td>P. Nielsen</td>
                 <td><span class="badge badge-danger">Overdue</span></td>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -396,6 +396,17 @@ a:hover {
 }
 
 /* ================================================================
+   OVERDUE ROW HIGHLIGHT
+   ================================================================ */
+.row--overdue {
+  border-left: 4px solid var(--color-overdue);
+}
+
+.row--overdue td:first-child {
+  padding-left: calc(var(--space-md) - 4px);
+}
+
+/* ================================================================
    UTILIZATION LABELS
    ================================================================ */
 .util-ok   { color: var(--color-success); font-weight: 600; }

--- a/docs/theme.css
+++ b/docs/theme.css
@@ -31,6 +31,8 @@
   --color-danger-border:    #f5b7b1;
   --color-danger-text:      #922b21;
 
+  --color-overdue:          #e53e3e;
+
   --color-info:             #3498db;
   --color-info-bg:          #d6eaf8;
   --color-info-border:      #aed6f1;


### PR DESCRIPTION
## Blueprint

**Approach:** Add a CSS class for overdue project rows that applies a red left border, define the color token in theme.css, and apply the class to the overdue row(s) in index.html.

**Key files:** `docs/theme.css`, `docs/styles.css`, `docs/index.html`

### Checklist
- [ ] In docs/theme.css, add a CSS custom property for the overdue border color, e.g. --color-overdue: #e53e3e (or a suitable red from the existing palette if one exists)
- [ ] In docs/styles.css, add a rule for a new class (e.g. .row--overdue or .project-row--overdue) that sets border-left: 4px solid var(--color-overdue) on the table row or list item element
- [ ] In docs/index.html, locate the overdue project row(s) and add the new CSS class to the appropriate <tr> or container element
- [ ] Verify the red left border is visually distinct and does not break the existing row layout (padding/alignment intact)
- [ ] Confirm no unintended files are staged (use git add docs/theme.css docs/styles.css docs/index.html only)
- [ ] Provide a complete git diff of all three modified files before submitting for review

---
_Automated by Hive - Task HIVE-20260313-b553e92b_