### PR TITLE
[#17] Overdue project highlight

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -158,7 +158,7 @@
                 <td class="col-right">$156,000</td>
                 <td>Apr 10, 2026</td>
               </tr>
-              <tr>
+              <tr class="overdue">
                 <td><a href="#" class="project-name">Legacy CRM Migration</a></td>
                 <td>P. Nielsen</td>
                 <td><span class="badge badge-danger">Overdue</span></td>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -301,6 +301,11 @@ a:hover {
   border-bottom: none;
 }
 
+/* -- Overdue row highlight ------------------------------------ */
+tr.overdue {
+  border-left: 4px solid var(--color-overdue);
+}
+
 /* -- Column alignment ----------------------------------------- */
 .col-right {
   text-align: right;

--- a/docs/theme.css
+++ b/docs/theme.css
@@ -30,6 +30,7 @@
   --color-danger-bg:        #fdedec;
   --color-danger-border:    #f5b7b1;
   --color-danger-text:      #922b21;
+  --color-overdue:          #dc2626;
 
   --color-info:             #3498db;
   --color-info-bg:          #d6eaf8;


### PR DESCRIPTION
## Blueprint

**Approach:** Add an 'overdue' CSS class to the overdue project row in index.html, then define a red left border style for that class in styles.css. Use a theme variable in theme.css for the overdue/danger color if one doesn't already exist.

**Key files:** `docs/index.html`, `docs/styles.css`, `docs/theme.css`

### Checklist
- [ ] Open docs/theme.css and check whether a red/danger color variable already exists (e.g. --color-danger or --color-error); if not, add one (e.g. --color-overdue: #dc2626)
- [ ] Open docs/styles.css and add a rule for the overdue row, e.g. `tr.overdue { border-left: 4px solid var(--color-overdue); }` — adjust selector to match the actual table/row markup in index.html
- [ ] Open docs/index.html, locate the overdue project row in the projects table, and add class="overdue" (or append 'overdue' to any existing classes) to that <tr> element
- [ ] Verify the red left border appears correctly on the overdue row and does not affect other rows
- [ ] Run `git diff docs/index.html docs/styles.css docs/theme.css` and confirm the diff is complete and correct before committing
- [ ] Stage only the three modified files with `git add docs/index.html docs/styles.css docs/theme.css` (avoid `git add .` to prevent accidental file mode changes)

---
_Automated by Hive - Task HIVE-20260313-3feee107_